### PR TITLE
feat: add read_config tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:http";
 import { registerStatsTools } from "./tools/stats.js";
 import { registerEventsTools } from "./tools/events.js";
 import { registerTokenTools } from "./tools/tokens.js";
+import { registerConfigTools } from "./tools/config.js";
 
 const PORT = parseInt(process.env.PORT ?? "3001", 10);
 
@@ -15,6 +16,7 @@ const server = new McpServer({
 registerStatsTools(server);
 registerEventsTools(server);
 registerTokenTools(server);
+registerConfigTools(server);
 
 const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
 await server.connect(transport);

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { fetchRepoFile } from "./github.js";
+
+const CONFIG_FILES = [
+  "ferrflow.json",
+  "ferrflow.json5",
+  "ferrflow.toml",
+  ".ferrflow",
+];
+
+export function registerConfigTools(server: McpServer) {
+  server.tool(
+    "read_config",
+    "Read and return the FerrFlow configuration from a GitHub repository. Tries ferrflow.json, ferrflow.json5, ferrflow.toml, and .ferrflow in order.",
+    {
+      owner: z.string().describe("GitHub repository owner"),
+      repo: z.string().describe("GitHub repository name"),
+      ref: z
+        .string()
+        .optional()
+        .describe("Git ref (branch, tag, or commit SHA). Defaults to the repo's default branch."),
+    },
+    async ({ owner, repo, ref }) => {
+      for (const filename of CONFIG_FILES) {
+        const content = await fetchRepoFile(owner, repo, filename, ref);
+        if (content !== null) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Found \`${filename}\`:\n\n\`\`\`\n${content}\`\`\``,
+              },
+            ],
+          };
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "No FerrFlow configuration file found in this repository. Looked for: " +
+              CONFIG_FILES.join(", "),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -7,14 +7,45 @@ interface GitHubContentResponse {
   path: string;
 }
 
+function validateOwnerOrRepoSegment(name: string, type: "owner" | "repo"): string {
+  if (!name) {
+    throw new Error(`GitHub ${type} must be a non-empty string`);
+  }
+
+  // Disallow path separators and simple traversal patterns.
+  if (name.includes("/") || name.includes("..")) {
+    throw new Error(`Invalid GitHub ${type}: "${name}"`);
+  }
+
+  // Restrict to a conservative subset of allowed characters.
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+    throw new Error(`Invalid GitHub ${type}: "${name}"`);
+  }
+
+  return name;
+}
+
+function encodePath(path: string): string {
+  // Encode each segment separately to avoid introducing or interpreting
+  // path separators or query/fragment characters from user input.
+  return path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
 export async function fetchRepoFile(
   owner: string,
   repo: string,
   path: string,
   ref?: string,
 ): Promise<string | null> {
+  const safeOwner = validateOwnerOrRepoSegment(owner, "owner");
+  const safeRepo = validateOwnerOrRepoSegment(repo, "repo");
+  const safePath = encodePath(path);
+
   const url = new URL(
-    `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
+    `https://api.github.com/repos/${safeOwner}/${safeRepo}/contents/${safePath}`,
   );
   if (ref) {
     url.searchParams.set("ref", ref);

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -1,0 +1,49 @@
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+interface GitHubContentResponse {
+  content: string;
+  encoding: string;
+  name: string;
+  path: string;
+}
+
+export async function fetchRepoFile(
+  owner: string,
+  repo: string,
+  path: string,
+  ref?: string,
+): Promise<string | null> {
+  const url = new URL(
+    `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
+  );
+  if (ref) {
+    url.searchParams.set("ref", ref);
+  }
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "ferrflow-mcp/0.2.0",
+  };
+
+  if (GITHUB_TOKEN) {
+    headers["Authorization"] = `Bearer ${GITHUB_TOKEN}`;
+  }
+
+  const res = await fetch(url.toString(), { headers });
+
+  if (res.status === 404) {
+    return null;
+  }
+
+  if (!res.ok) {
+    throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as GitHubContentResponse;
+
+  if (data.encoding === "base64") {
+    return Buffer.from(data.content, "base64").toString("utf-8");
+  }
+
+  return data.content;
+}


### PR DESCRIPTION
## Summary

- Add `read_config` MCP tool that fetches FerrFlow config from any GitHub repository
- Add `github.ts` helper for fetching repo file contents via GitHub API
- Tries config files in priority order: `ferrflow.json`, `ferrflow.json5`, `ferrflow.toml`, `.ferrflow`
- Supports optional `ref` parameter to read config from a specific branch/tag/commit
- Uses `GITHUB_TOKEN` env var for authenticated requests (optional, works without for public repos)

Closes #12