### PR TITLE
fix(ci): trigger Docker builds on tag creation instead of CI release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.test.result == 'success') || (github.event_name == 'workflow_dispatch' && needs.test.result == 'success')
     permissions:
       contents: write
-      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -67,25 +66,3 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
         env:
           GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
-      - name: Build and push Docker image
-        if: inputs.dry_run != 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          version=$(git tag --list "mcp@v*" --sort=-version:refname | head -1 | sed 's/.*@v//')
-          if [ -z "$version" ]; then
-            echo "No version tag found, skipping image push"
-            exit 0
-          fi
-          major_minor=$(echo ${version} | cut -d. -f1-2)
-
-          echo "${GITHUB_TOKEN}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          docker build -t ghcr.io/ferrflow-org/mcp:${version} .
-          docker tag ghcr.io/ferrflow-org/mcp:${version} ghcr.io/ferrflow-org/mcp:${major_minor}
-          docker tag ghcr.io/ferrflow-org/mcp:${version} ghcr.io/ferrflow-org/mcp:latest
-
-          docker push ghcr.io/ferrflow-org/mcp:${version}
-          docker push ghcr.io/ferrflow-org/mcp:${major_minor}
-          docker push ghcr.io/ferrflow-org/mcp:latest
-
-          echo "Pushed mcp:${version}, ${major_minor}, latest"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (without v prefix)'
+        required: true
+
+jobs:
+  build-and-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Extract version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          fi
+      - name: Build and push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          MAJOR_MINOR=$(echo ${VERSION} | cut -d. -f1-2)
+
+          echo "${GITHUB_TOKEN}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker build -t ghcr.io/ferrflow-org/mcp:${VERSION} .
+          docker tag ghcr.io/ferrflow-org/mcp:${VERSION} ghcr.io/ferrflow-org/mcp:${MAJOR_MINOR}
+          docker tag ghcr.io/ferrflow-org/mcp:${VERSION} ghcr.io/ferrflow-org/mcp:latest
+
+          docker push ghcr.io/ferrflow-org/mcp:${VERSION}
+          docker push ghcr.io/ferrflow-org/mcp:${MAJOR_MINOR}
+          docker push ghcr.io/ferrflow-org/mcp:latest
+
+          echo "Pushed mcp:${VERSION}, ${MAJOR_MINOR}, latest"


### PR DESCRIPTION
## Summary
- Move Docker build from CI release job to a dedicated docker.yml triggered by tag creation
- Supports both v* and mcp@v* tag formats
- Add workflow_dispatch for manual Docker builds
- Remove Docker-related steps and packages permission from CI release job

Same pattern as Application repo.

Closes #28

## Test plan
- [ ] CI runs without Docker build step
- [ ] Docker workflow triggers on tag push
- [ ] Manual workflow_dispatch builds correctly