### PR TITLE
chore: migrate .ferrflow config to camelCase keys

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -1,15 +1,16 @@
 {
   "workspace": {
     "remote": "origin",
-    "branch": "main"
+    "branch": "main",
+    "tagTemplate": "v{version}"
   },
   "package": [
     {
       "name": "mcp",
       "path": ".",
       "changelog": "CHANGELOG.md",
-      "shared_paths": ["src/"],
-      "versioned_files": [
+      "sharedPaths": ["src/"],
+      "versionedFiles": [
         { "path": "package.json", "format": "json" }
       ]
     }


### PR DESCRIPTION
## Summary
- Migrates `.ferrflow` config keys to camelCase: `tagTemplate`, `versionedFiles`, `sharedPaths`
- Adds `tagTemplate: "v{version}"` (previously in PR #29, now combined)
- Aligns with FerrFlow-Org/FerrFlow#93