### PR TITLE
chore: enable automatic rebase for renovate branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
+  "rebaseWhen": "behind-base-branch",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "minor"],


### PR DESCRIPTION
## Summary
- Adds `rebaseWhen: behind-base-branch` to keep Renovate branches automatically rebased

🤖 Generated with [Claude Code](https://claude.com/claude-code)