### PR TITLE
fix(ci): use release event to trigger Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,8 @@
 name: Docker
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -25,7 +24,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
           else
-            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
           fi
       - name: Build and push
         env:


### PR DESCRIPTION
Closes #34

Tags pushed by FerrFlow via fine-grained PAT don't trigger downstream workflows (GitHub anti-loop protection). Switches `docker.yml` from `push: tags` to `release: published`.