### PR TITLE
chore(release): sync v0.3.1 release commit to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `mcp` will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.1] - 2026-03-29
+
+### Bug Fixes
+
+- fix(ci): trigger Docker builds on tag creation and use v* tag format (#29)
+
 ## [0.3.0] - 2026-03-28
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.3.0"
+  "version": "0.3.1"
 }


### PR DESCRIPTION
## Summary
- Cherry-pick the release commit from tag v0.3.1 onto main
- The release commit was created by FerrFlow but failed to push to main due to ruleset restrictions

Closes #136