### PR TITLE
feat(tools): add list_release_tags tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pnpm dev
 | `get_stats` | Get public usage statistics |
 | `health_check` | Check API health status |
 | `record_event` | Record an analytics event |
+| `list_release_tags` | List release tags for a package |
 
 ## Stack
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { registerStatsTools } from "./tools/stats.js";
 import { registerEventsTools } from "./tools/events.js";
 import { registerTokenTools } from "./tools/tokens.js";
 import { registerConfigTools } from "./tools/config.js";
+import { registerTagsTools } from "./tools/tags.js";
 
 const PORT = parseInt(process.env.PORT ?? "3001", 10);
 
@@ -17,6 +18,7 @@ registerStatsTools(server);
 registerEventsTools(server);
 registerTokenTools(server);
 registerConfigTools(server);
+registerTagsTools(server);
 
 const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
 await server.connect(transport);

--- a/src/tools/__tests__/github.test.ts
+++ b/src/tools/__tests__/github.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchMatchingTags } from "../github.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Not Found",
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe("fetchMatchingTags", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("returns matching tag refs sorted by the API", async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse([
+        { ref: "refs/tags/cli@v1.0.0" },
+        { ref: "refs/tags/cli@v1.1.0" },
+        { ref: "refs/tags/cli@v2.0.0" },
+      ]),
+    );
+    const tags = await fetchMatchingTags("FerrFlow-Org", "ferrflow", "cli");
+    expect(tags).toEqual(["cli@v1.0.0", "cli@v1.1.0", "cli@v2.0.0"]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/git/matching-refs/tags/cli%40v"),
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("returns empty array when no tags match", async () => {
+    mockFetch.mockResolvedValue(makeResponse([]));
+    const tags = await fetchMatchingTags("FerrFlow-Org", "ferrflow", "nonexistent");
+    expect(tags).toEqual([]);
+  });
+
+  it("throws on API error", async () => {
+    mockFetch.mockResolvedValue(makeResponse([], 403));
+    await expect(
+      fetchMatchingTags("FerrFlow-Org", "ferrflow", "cli"),
+    ).rejects.toThrow("GitHub API error: 403");
+  });
+
+  it("rejects invalid owner", async () => {
+    await expect(
+      fetchMatchingTags("../evil", "ferrflow", "cli"),
+    ).rejects.toThrow("Invalid GitHub owner");
+  });
+});

--- a/src/tools/__tests__/tags.test.ts
+++ b/src/tools/__tests__/tags.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTagsTools } from "../tags.js";
+
+vi.mock("../github.js", () => ({
+  fetchMatchingTags: vi.fn(),
+}));
+
+import { fetchMatchingTags } from "../github.js";
+const mockFetchMatchingTags = vi.mocked(fetchMatchingTags);
+
+let toolHandler: (params: Record<string, unknown>) => Promise<unknown>;
+
+const mockServer = {
+  tool: vi.fn((_name, _desc, _schema, handler) => {
+    toolHandler = handler;
+  }),
+} as unknown as McpServer;
+
+describe("list_release_tags", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registerTagsTools(mockServer);
+  });
+
+  it("registers the tool with correct name", () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      "list_release_tags",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns tags sorted by semver descending", async () => {
+    mockFetchMatchingTags.mockResolvedValue([
+      "cli@v1.0.0",
+      "cli@v1.1.0",
+      "cli@v2.0.0",
+      "cli@v1.2.3",
+    ]);
+
+    const result = await toolHandler({
+      owner: "FerrFlow-Org",
+      repo: "ferrflow",
+      package_name: "cli",
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            [
+              { tag: "cli@v2.0.0", version: "2.0.0" },
+              { tag: "cli@v1.2.3", version: "1.2.3" },
+              { tag: "cli@v1.1.0", version: "1.1.0" },
+              { tag: "cli@v1.0.0", version: "1.0.0" },
+            ],
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("returns a message when no tags found", async () => {
+    mockFetchMatchingTags.mockResolvedValue([]);
+
+    const result = (await toolHandler({
+      owner: "FerrFlow-Org",
+      repo: "ferrflow",
+      package_name: "nonexistent",
+    })) as { content: { text: string }[] };
+
+    expect(result.content[0].text).toContain("No release tags found");
+  });
+});

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -78,3 +78,37 @@ export async function fetchRepoFile(
 
   return data.content;
 }
+
+interface GitHubRefResponse {
+  ref: string;
+}
+
+export async function fetchMatchingTags(
+  owner: string,
+  repo: string,
+  packageName: string,
+): Promise<string[]> {
+  const safeOwner = validateOwnerOrRepoSegment(owner, "owner");
+  const safeRepo = validateOwnerOrRepoSegment(repo, "repo");
+  const prefix = encodeURIComponent(`${packageName}@v`);
+
+  const url = `https://api.github.com/repos/${safeOwner}/${safeRepo}/git/matching-refs/tags/${prefix}`;
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "ferrflow-mcp/0.3.1",
+  };
+
+  if (GITHUB_TOKEN) {
+    headers["Authorization"] = `Bearer ${GITHUB_TOKEN}`;
+  }
+
+  const res = await fetch(url, { headers });
+
+  if (!res.ok) {
+    throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as GitHubRefResponse[];
+  return data.map((ref) => ref.ref.replace("refs/tags/", ""));
+}

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { fetchMatchingTags } from "./github.js";
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) !== (pb[i] ?? 0)) {
+      return (pa[i] ?? 0) - (pb[i] ?? 0);
+    }
+  }
+  return 0;
+}
+
+export function registerTagsTools(server: McpServer) {
+  server.tool(
+    "list_release_tags",
+    "List git release tags for a package (matching name@v*), sorted by version descending.",
+    {
+      owner: z.string().describe("GitHub repository owner"),
+      repo: z.string().describe("GitHub repository name"),
+      package_name: z.string().describe("Package name to match tags against (e.g. 'cli' matches 'cli@v*')"),
+    },
+    async ({ owner, repo, package_name }) => {
+      const tags = await fetchMatchingTags(owner, repo, package_name);
+
+      if (tags.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `No release tags found for "${package_name}" in ${owner}/${repo}.`,
+            },
+          ],
+        };
+      }
+
+      const entries = tags
+        .map((tag) => {
+          const version = tag.replace(`${package_name}@v`, "");
+          return { tag, version };
+        })
+        .sort((a, b) => compareSemver(b.version, a.version));
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(entries, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `fetchMatchingTags` utility to `github.ts` using the GitHub matching-refs API
- Add `list_release_tags` MCP tool that lists release tags for a package (`name@v*`), sorted by semver descending
- Register the tool and update README

Closes #13

## Test plan

- [x] `fetchMatchingTags` unit tests (4 tests): matching refs, empty results, API errors, input validation
- [x] `list_release_tags` tool tests (3 tests): registration, semver sort, empty results
- [x] Typecheck passes
- [x] Full test suite passes (13 tests)