### PR TITLE
feat: add stdio transport for local usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@
 
 ## Quick Start
 
+**Local (stdio) — for Claude Code, Cursor, etc.:**
+
+```json
+{
+  "mcpServers": {
+    "ferrflow": {
+      "command": "npx",
+      "args": ["-y", "@ferrflow/mcp", "--stdio"]
+    }
+  }
+}
+```
+
+**Server (HTTP) — for shared/deployed usage:**
+
 ```bash
 pnpm install
 pnpm dev

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "node": ">=22.0.0",
     "pnpm": ">=9.0.0"
   },
+  "bin": {
+    "ferrflow-mcp": "./dist/index.js"
+  },
   "main": "./dist/index.js",
   "name": "@ferrflow/mcp",
   "private": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
+#!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { createServer } from "node:http";
 import { registerStatsTools } from "./tools/stats.js";
 import { registerEventsTools } from "./tools/events.js";
 import { registerTokenTools } from "./tools/tokens.js";
@@ -8,11 +7,9 @@ import { registerConfigTools } from "./tools/config.js";
 import { registerTagsTools } from "./tools/tags.js";
 import { registerChangelogTools } from "./tools/changelog.js";
 
-const PORT = parseInt(process.env.PORT ?? "3001", 10);
-
 const server = new McpServer({
   name: "ferrflow",
-  version: "0.2.0",
+  version: "1.0.0",
 });
 
 registerStatsTools(server);
@@ -22,18 +19,36 @@ registerConfigTools(server);
 registerTagsTools(server);
 registerChangelogTools(server);
 
-const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-await server.connect(transport);
+const useStdio = process.argv.includes("--stdio");
 
-const httpServer = createServer((req, res) => {
-  if (req.method === "GET" && req.url === "/health") {
-    res.writeHead(200);
-    res.end("ok");
-    return;
-  }
-  transport.handleRequest(req, res);
-});
+if (useStdio) {
+  const { StdioServerTransport } = await import(
+    "@modelcontextprotocol/sdk/server/stdio.js"
+  );
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+} else {
+  const { StreamableHTTPServerTransport } = await import(
+    "@modelcontextprotocol/sdk/server/streamableHttp.js"
+  );
+  const { createServer } = await import("node:http");
 
-httpServer.listen(PORT, () => {
-  console.log(`MCP server listening on port ${PORT}`);
-});
+  const PORT = parseInt(process.env.PORT ?? "3001", 10);
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  await server.connect(transport);
+
+  const httpServer = createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/health") {
+      res.writeHead(200);
+      res.end("ok");
+      return;
+    }
+    transport.handleRequest(req, res);
+  });
+
+  httpServer.listen(PORT, () => {
+    console.log(`MCP server listening on port ${PORT}`);
+  });
+}


### PR DESCRIPTION
## Summary

- Add `--stdio` flag to run the MCP server over stdin/stdout instead of HTTP
- Add `bin` entry in package.json so `npx @ferrflow/mcp --stdio` works
- Default remains HTTP for server deployments
- Update README with usage instructions for both modes

This enables local/private usage via Claude Code, Cursor, etc. without exposing anything on the network. Enterprise users can run the server locally with their own tokens.

Closes #51