### PR TITLE
chore(release): force version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `mcp` will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.1.0] - 2026-04-01
+
+### Features
+
+- feat: add stdio transport for local usage (#52)
+- feat(tools): add read_changelog tool (#49)
+- feat(tools): add list_release_tags tool (#46)
+
 ## [0.3.1] - 2026-03-29
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { registerChangelogTools } from "./tools/changelog.js";
 
 const server = new McpServer({
   name: "ferrflow",
-  version: "1.0.0",
+  version: "1.1.0",
 });
 
 registerStatsTools(server);


### PR DESCRIPTION
## Summary

- Fix incorrect v2.0.0 bump caused by a pre-existing `chore!:` commit being re-counted after the v1.0.0 force
- Update version to 1.1.0 in package.json and index.ts
- Add CHANGELOG entry for 1.1.0
- Deleted the v2.0.0 release and tag

The v2.0.0 tag and GitHub release have already been removed.