### PR TITLE
feat(tools): add dry_run tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { registerTokenTools } from "./tools/tokens.js";
 import { registerConfigTools } from "./tools/config.js";
 import { registerTagsTools } from "./tools/tags.js";
 import { registerChangelogTools } from "./tools/changelog.js";
+import { registerDryRunTools } from "./tools/dry-run.js";
 
 const server = new McpServer({
   name: "ferrflow",
@@ -18,6 +19,7 @@ registerTokenTools(server);
 registerConfigTools(server);
 registerTagsTools(server);
 registerChangelogTools(server);
+registerDryRunTools(server);
 
 const useStdio = process.argv.includes("--stdio");
 

--- a/src/tools/__tests__/dry-run.test.ts
+++ b/src/tools/__tests__/dry-run.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerDryRunTools } from "../dry-run.js";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from "node:child_process";
+const mockExecFile = vi.mocked(execFile);
+
+let toolHandler: (params: Record<string, unknown>) => Promise<unknown>;
+
+const mockServer = {
+  tool: vi.fn((_name: string, _desc: string, _schema: unknown, handler: (params: Record<string, unknown>) => Promise<unknown>) => {
+    toolHandler = handler;
+  }),
+} as unknown as McpServer;
+
+describe("dry_run", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registerDryRunTools(mockServer);
+  });
+
+  it("registers the tool with correct name", () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      "dry_run",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns parsed JSON from ferrflow check", async () => {
+    const output = JSON.stringify({
+      packages: [
+        {
+          name: "api",
+          current_version: "1.2.3",
+          next_version: "1.3.0",
+          bump_type: "minor",
+          tag: "api@v1.3.0",
+          commits: [{ hash: "abc1234", message: "feat(api): add endpoint" }],
+        },
+      ],
+    });
+
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      (callback as Function)(null, output, "");
+      return undefined as never;
+    });
+
+    const result = (await toolHandler({})) as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.packages).toHaveLength(1);
+    expect(parsed.packages[0].name).toBe("api");
+    expect(parsed.packages[0].next_version).toBe("1.3.0");
+  });
+
+  it("returns empty packages when nothing to bump", async () => {
+    const output = JSON.stringify({ packages: [] });
+
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      (callback as Function)(null, output, "");
+      return undefined as never;
+    });
+
+    const result = (await toolHandler({})) as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.packages).toHaveLength(0);
+  });
+
+  it("uses provided path as cwd", async () => {
+    const output = JSON.stringify({ packages: [] });
+
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      (callback as Function)(null, output, "");
+      return undefined as never;
+    });
+
+    await toolHandler({ path: "/tmp/my-repo" });
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "ferrflow",
+      ["check", "--json"],
+      expect.objectContaining({ cwd: "/tmp/my-repo" }),
+      expect.any(Function),
+    );
+  });
+
+  it("throws when ferrflow is not found", async () => {
+    const err = Object.assign(new Error("not found"), { code: "ENOENT" });
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      (callback as Function)(err, "", "");
+      return undefined as never;
+    });
+
+    await expect(toolHandler({})).rejects.toThrow("ferrflow CLI not found");
+  });
+
+  it("throws on non-zero exit with stderr", async () => {
+    const err = Object.assign(new Error("exit 1"), { code: 1 });
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      (callback as Function)(err, "", "No ferrflow config found");
+      return undefined as never;
+    });
+
+    await expect(toolHandler({})).rejects.toThrow("No ferrflow config found");
+  });
+});

--- a/src/tools/dry-run.ts
+++ b/src/tools/dry-run.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { execFile } from "node:child_process";
+
+function runFerrflowCheck(cwd?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "ferrflow",
+      ["check", "--json"],
+      { cwd: cwd || process.cwd(), timeout: 30_000 },
+      (error, stdout, stderr) => {
+        if (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            reject(
+              new Error(
+                "ferrflow CLI not found. Make sure it is installed and in your PATH.",
+              ),
+            );
+            return;
+          }
+          reject(new Error(stderr.trim() || error.message));
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+export function registerDryRunTools(server: McpServer) {
+  server.tool(
+    "dry_run",
+    "Run a ferrflow dry-run on a local repository and return what would be bumped and released.",
+    {
+      path: z
+        .string()
+        .optional()
+        .describe(
+          "Local path to the repository. Defaults to the current working directory.",
+        ),
+    },
+    async ({ path }) => {
+      const output = await runFerrflowCheck(path);
+      const result = JSON.parse(output);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `dry_run` MCP tool that runs `ferrflow check --json` locally and returns structured release preview data
- Accepts optional `path` parameter (defaults to cwd)
- Returns clear errors when CLI is not found or execution fails

Closes #11

## Test plan
- [x] `pnpm test` — 32 tests pass (5 new for dry_run)
- [x] `pnpm typecheck` passes
- [ ] Manual test: invoke `dry_run` tool via MCP stdio with a local repo