### PR TITLE
chore(release): mcp v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `mcp` will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.1.0] - 2026-03-31
+
+### Features
+
+- feat(tools): add dry_run tool (#55)
+
 ## [1.1.0] - 2026-04-01
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "bin": {
+    "ferrflow-mcp": "./dist/index.js"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^4.3.6"
@@ -14,9 +17,6 @@
     "node": ">=22.0.0",
     "pnpm": ">=9.0.0"
   },
-  "bin": {
-    "ferrflow-mcp": "./dist/index.js"
-  },
   "main": "./dist/index.js",
   "name": "@ferrflow/mcp",
   "private": true,
@@ -29,5 +29,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "2.0.0"
+  "version": "2.1.0"
 }


### PR DESCRIPTION
## Summary
- Land the orphaned release commit for v2.1.0
- The original release push was silently rejected by the branch ruleset (missing admin bypass actor, now fixed)
- Updates package.json to 2.1.0 and adds changelog entry

## Test plan
- [ ] package.json version matches v2.1.0 after merge
- [ ] Tag v2.1.0 points to a commit on main