### PR TITLE
feat: publish @ferrflow/mcp to npm on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    name: Publish npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm build
+      - run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "ferrflow-mcp": "./dist/index.js"
   },
   "description": "Model Context Protocol server for the FerrFlow ecosystem",
-  "license": "MIT",
+  "license": "MPL-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/FerrFlow-Org/MCP.git"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,19 @@
   "bin": {
     "ferrflow-mcp": "./dist/index.js"
   },
+  "description": "Model Context Protocol server for the FerrFlow ecosystem",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FerrFlow-Org/MCP.git"
+  },
+  "keywords": [
+    "mcp",
+    "ferrflow",
+    "model-context-protocol",
+    "ai",
+    "release-management"
+  ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^4.3.6"
@@ -17,9 +30,14 @@
     "node": ">=22.0.0",
     "pnpm": ">=9.0.0"
   },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.js",
   "name": "@ferrflow/mcp",
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/index.ts",


### PR DESCRIPTION
Closes #63

- Remove `"private": true` from package.json
- Add `publishConfig.access: "public"` for scoped package
- Add `files` field to only ship `dist/`
- Add npm metadata (description, license, repository, keywords)
- Add `release.yml` workflow that publishes to npm on GitHub release

Requires `NPM_TOKEN` secret to be configured in the repo.