### PR TITLE
feat(tools): add validate_config tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "ajv": "^8.18.0",
     "zod": "^4.3.6"
   },
   "description": "Model Context Protocol server for the FerrFlow ecosystem",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.29.0(zod@4.3.6)
+      ajv:
+        specifier: ^8.18.0
+        version: 8.18.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -289,42 +292,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -710,28 +707,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { registerConfigTools } from "./tools/config.js";
 import { registerTagsTools } from "./tools/tags.js";
 import { registerChangelogTools } from "./tools/changelog.js";
 import { registerDryRunTools } from "./tools/dry-run.js";
+import { registerValidateTools } from "./tools/validate.js";
 
 const server = new McpServer({
   name: "ferrflow",
@@ -20,6 +21,7 @@ registerConfigTools(server);
 registerTagsTools(server);
 registerChangelogTools(server);
 registerDryRunTools(server);
+registerValidateTools(server);
 
 const { StdioServerTransport } = await import(
   "@modelcontextprotocol/sdk/server/stdio.js"

--- a/src/schema/ferrflow.json
+++ b/src/schema/ferrflow.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ferrflow.com/schema/ferrflow.json",
+  "title": "FerrFlow Configuration",
+  "description": "Configuration file for FerrFlow — universal semantic versioning for monorepos and classic repos.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference for editor autocompletion."
+    },
+    "workspace": {
+      "type": "object",
+      "description": "Workspace-level settings.",
+      "properties": {
+        "remote": {
+          "type": "string",
+          "description": "Git remote name.",
+          "default": "origin"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Main branch name.",
+          "default": "main"
+        },
+        "anonymous_telemetry": {
+          "type": "boolean",
+          "description": "Send anonymous usage statistics to improve FerrFlow. No identifying data is collected.",
+          "default": true
+        },
+        "telemetry": {
+          "type": "boolean",
+          "description": "Deprecated: use anonymous_telemetry instead.",
+          "default": true
+        },
+        "versioning": {
+          "type": "string",
+          "description": "Default versioning strategy for all packages.",
+          "enum": ["semver", "calver", "calver-short", "calver-seq", "sequential", "zerover"],
+          "default": "semver"
+        },
+        "tagTemplate": {
+          "type": "string",
+          "description": "Tag template. Use {name} for package name and {version} for version. Default: 'v{version}' for single repos, '{name}@v{version}' for monorepos.",
+          "examples": ["v{version}", "{name}@v{version}", "{name}/v{version}", "release-{version}"]
+        },
+        "recoverMissedReleases": {
+          "type": "boolean",
+          "description": "Compare files against the last tag instead of just the last commit, recovering missed releases in monorepos.",
+          "default": false
+        },
+        "releaseCommitMode": {
+          "type": "string",
+          "description": "How to commit version bumps and changelog updates. 'commit' pushes directly to the branch, 'pr' creates a pull request, 'none' skips committing entirely.",
+          "enum": ["commit", "pr", "none"],
+          "default": "commit"
+        },
+        "autoMergeReleases": {
+          "type": "boolean",
+          "description": "Automatically merge release PRs when releaseCommitMode is 'pr'.",
+          "default": true
+        },
+        "skipCi": {
+          "type": "boolean",
+          "description": "Append [skip ci] to the release commit message. Defaults to true in 'commit' mode, false in 'pr' mode."
+        },
+        "floatingTags": {
+          "type": "array",
+          "description": "Floating tag levels to create/move on each release. Each level produces a tag pointing to the latest matching release (e.g. 'major' creates a v1 tag for v1.2.3).",
+          "items": {
+            "type": "string",
+            "enum": ["major", "minor"]
+          },
+          "default": []
+        },
+        "orphanedTagStrategy": {
+          "type": "string",
+          "enum": ["warn", "treeHash", "message"],
+          "description": "How to handle tags pointing to orphaned commits (after rebase + force-push). 'warn' logs a warning and skips. 'treeHash' attempts recovery by matching the commit's tree hash. 'message' attempts recovery by matching the commit message.",
+          "default": "warn"
+        },
+        "hooks": {
+          "$ref": "#/$defs/hooks"
+        }
+      },
+      "additionalProperties": false
+    },
+    "package": {
+      "type": "array",
+      "description": "List of packages to version. Use one entry for single repos, multiple for monorepos.",
+      "items": {
+        "type": "object",
+        "required": ["name", "path"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Package name, used in tags and changelog headers."
+          },
+          "path": {
+            "type": "string",
+            "description": "Path to the package root, relative to the repo root. Use \".\" for single repos."
+          },
+          "changelog": {
+            "type": ["string", "null"],
+            "description": "Path to the changelog file, relative to the repo root."
+          },
+          "versionedFiles": {
+            "type": "array",
+            "description": "Files that contain the package version to update on release.",
+            "items": {
+              "type": "object",
+              "required": ["path", "format"],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "Path to the version file, relative to the repo root."
+                },
+                "format": {
+                  "type": "string",
+                  "description": "File format used to locate and update the version field.",
+                  "enum": ["csproj", "toml", "json", "xml", "gradle", "gomod", "helm", "txt"]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "sharedPaths": {
+            "type": "array",
+            "description": "Paths whose changes should trigger a version bump for this package (monorepo only).",
+            "items": {
+              "type": "string"
+            }
+          },
+          "versioning": {
+            "type": "string",
+            "description": "Versioning strategy for this package. Overrides workspace default.",
+            "enum": ["semver", "calver", "calver-short", "calver-seq", "sequential", "zerover"]
+          },
+          "tagTemplate": {
+            "type": "string",
+            "description": "Tag template for this package. Use {name} for package name and {version} for version. Overrides workspace default.",
+            "examples": ["v{version}", "{name}@v{version}", "{name}/v{version}", "release-{version}"]
+          },
+          "floatingTags": {
+            "type": "array",
+            "description": "Floating tag levels for this package. Overrides workspace default.",
+            "items": {
+              "type": "string",
+              "enum": ["major", "minor"]
+            }
+          },
+          "hooks": {
+            "$ref": "#/$defs/hooks"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "$defs": {
+    "hooks": {
+      "type": "object",
+      "description": "Shell commands executed at lifecycle points during release.",
+      "properties": {
+        "preBump": {
+          "type": "string",
+          "description": "Run after bump calculation, before writing version files."
+        },
+        "postBump": {
+          "type": "string",
+          "description": "Run after writing version files, before changelog generation."
+        },
+        "preCommit": {
+          "type": "string",
+          "description": "Run after changelog generation, before git commit."
+        },
+        "prePublish": {
+          "type": "string",
+          "description": "Run after commit and tag, before push."
+        },
+        "postPublish": {
+          "type": "string",
+          "description": "Run after push and release creation."
+        },
+        "onFailure": {
+          "type": "string",
+          "description": "Behavior when a hook exits non-zero.",
+          "enum": ["abort", "continue"],
+          "default": "abort"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/tools/__tests__/validate.test.ts
+++ b/src/tools/__tests__/validate.test.ts
@@ -241,3 +241,67 @@ describe("checkPaths — local mode", () => {
     expect(result.suggestions).toEqual([]);
   });
 });
+
+describe("checkPaths — github mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns error when package path does not exist on GitHub", async () => {
+    mockFetch.mockResolvedValue(makeResponse(null, 404));
+
+    const config = {
+      package: [{ name: "app", path: "packages/app", versionedFiles: [] }],
+    };
+    const result = await checkPaths(config, "github", { owner: "org", repo: "repo" });
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining("packages/app") }),
+      ]),
+    );
+  });
+
+  it("returns error when versioned file missing on GitHub", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeResponse({ content: "", encoding: "base64" }),
+    );
+    mockFetch.mockResolvedValueOnce(makeResponse(null, 404));
+
+    const config = {
+      package: [
+        {
+          name: "app",
+          path: "packages/app",
+          versionedFiles: [{ path: "packages/app/package.json", format: "json" }],
+        },
+      ],
+    };
+    const result = await checkPaths(config, "github", { owner: "org", repo: "repo" });
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining("package.json") }),
+      ]),
+    );
+  });
+
+  it("returns no errors when all paths exist on GitHub", async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse({ content: Buffer.from("content").toString("base64"), encoding: "base64" }),
+    );
+
+    const config = {
+      workspace: { tagTemplate: "v{version}", orphanedTagStrategy: "warn" },
+      package: [
+        {
+          name: "app",
+          path: ".",
+          versionedFiles: [{ path: "package.json", format: "json" }],
+          changelog: "CHANGELOG.md",
+        },
+      ],
+    };
+    const result = await checkPaths(config, "github", { owner: "org", repo: "repo" });
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/src/tools/__tests__/validate.test.ts
+++ b/src/tools/__tests__/validate.test.ts
@@ -66,11 +66,21 @@ describe("resolveConfig", () => {
     expect(result.config).toEqual({ package: [{ name: "api", path: "packages/api" }] });
   });
 
-  it("returns error for invalid JSON", async () => {
+  it("returns error for invalid JSON instead of skipping to next file", async () => {
     mockReadFile.mockResolvedValueOnce("not valid json {{{");
 
     const result = await resolveConfig("local", { path: "/repo" });
-    expect(result.error).toBeDefined();
+    expect(result.error).toMatch(/Failed to parse ferrflow\.json/);
+    expect(result.config).toBeUndefined();
+  });
+
+  it("returns error for TOML config file", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT")); // ferrflow.json
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT")); // ferrflow.json5
+    mockReadFile.mockResolvedValueOnce("[package]\nname = 'app'"); // ferrflow.toml
+
+    const result = await resolveConfig("local", { path: "/repo" });
+    expect(result.error).toMatch(/TOML parsing not yet supported/);
   });
 });
 

--- a/src/tools/__tests__/validate.test.ts
+++ b/src/tools/__tests__/validate.test.ts
@@ -13,7 +13,7 @@ import { readFile, access } from "node:fs/promises";
 const mockReadFile = vi.mocked(readFile);
 const mockAccess = vi.mocked(access);
 
-import { resolveConfig, validateSchema } from "../validate.js";
+import { resolveConfig, validateSchema, checkPaths } from "../validate.js";
 
 function makeResponse(body: unknown, status = 200): Response {
   return {
@@ -106,5 +106,138 @@ describe("validateSchema", () => {
     };
     const errors = validateSchema(config);
     expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("checkPaths — local mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns error when package path does not exist", async () => {
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    const config = {
+      package: [{ name: "app", path: "packages/app", versionedFiles: [] }],
+    };
+    const result = await checkPaths(config, "local", { path: "/repo" });
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining("packages/app") }),
+      ]),
+    );
+  });
+
+  it("returns error when versioned file does not exist", async () => {
+    mockAccess.mockResolvedValueOnce(undefined); // package path exists
+    mockAccess.mockRejectedValueOnce(new Error("ENOENT")); // versioned file missing
+
+    const config = {
+      package: [
+        {
+          name: "app",
+          path: "packages/app",
+          versionedFiles: [{ path: "packages/app/Cargo.toml", format: "toml" }],
+        },
+      ],
+    };
+    const result = await checkPaths(config, "local", { path: "/repo" });
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining("Cargo.toml") }),
+      ]),
+    );
+  });
+
+  it("returns warning when changelog does not exist", async () => {
+    mockAccess.mockResolvedValueOnce(undefined); // package path
+    mockAccess.mockRejectedValueOnce(new Error("ENOENT")); // changelog
+
+    const config = {
+      package: [{ name: "app", path: ".", changelog: "CHANGELOG.md" }],
+    };
+    const result = await checkPaths(config, "local", { path: "/repo" });
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining("CHANGELOG.md") }),
+      ]),
+    );
+  });
+
+  it("returns warning when sharedPaths dir does not exist", async () => {
+    mockAccess.mockResolvedValueOnce(undefined); // package path
+    mockAccess.mockRejectedValueOnce(new Error("ENOENT")); // sharedPaths
+
+    const config = {
+      package: [{ name: "app", path: ".", sharedPaths: ["packages/shared"] }],
+    };
+    const result = await checkPaths(config, "local", { path: "/repo" });
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining("packages/shared") }),
+      ]),
+    );
+  });
+
+  it("returns suggestion when no versionedFiles declared", async () => {
+    mockAccess.mockResolvedValue(undefined);
+
+    const config = {
+      package: [{ name: "app", path: "." }],
+    };
+    const result = await checkPaths(config, "local", { path: "/repo" });
+    expect(result.suggestions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining("versionedFiles") }),
+      ]),
+    );
+  });
+
+  it("returns suggestion when orphanedTagStrategy not set", async () => {
+    mockAccess.mockResolvedValue(undefined);
+
+    const config = {
+      package: [{ name: "app", path: "." }],
+    };
+    const result = await checkPaths(config, "local", { path: "/repo" });
+    expect(result.suggestions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "workspace.orphanedTagStrategy" }),
+      ]),
+    );
+  });
+
+  it("returns suggestion when tagTemplate not set", async () => {
+    mockAccess.mockResolvedValue(undefined);
+
+    const config = {
+      package: [{ name: "app", path: "." }],
+    };
+    const result = await checkPaths(config, "local", { path: "/repo" });
+    expect(result.suggestions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "workspace.tagTemplate" }),
+      ]),
+    );
+  });
+
+  it("returns no issues for fully valid config with all paths existing", async () => {
+    mockAccess.mockResolvedValue(undefined);
+
+    const config = {
+      workspace: { tagTemplate: "v{version}", orphanedTagStrategy: "warn" },
+      package: [
+        {
+          name: "app",
+          path: ".",
+          versionedFiles: [{ path: "package.json", format: "json" }],
+          changelog: "CHANGELOG.md",
+        },
+      ],
+    };
+    const result = await checkPaths(config, "local", { path: "/repo" });
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.suggestions).toEqual([]);
   });
 });

--- a/src/tools/__tests__/validate.test.ts
+++ b/src/tools/__tests__/validate.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { CONFIG_FILES } from "../config.js";
+
+describe("CONFIG_FILES", () => {
+  it("is exported and contains expected filenames", () => {
+    expect(CONFIG_FILES).toContain("ferrflow.json");
+    expect(CONFIG_FILES).toContain(".ferrflow");
+    expect(CONFIG_FILES.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/tools/__tests__/validate.test.ts
+++ b/src/tools/__tests__/validate.test.ts
@@ -13,7 +13,7 @@ import { readFile, access } from "node:fs/promises";
 const mockReadFile = vi.mocked(readFile);
 const mockAccess = vi.mocked(access);
 
-import { resolveConfig } from "../validate.js";
+import { resolveConfig, validateSchema } from "../validate.js";
 
 function makeResponse(body: unknown, status = 200): Response {
   return {
@@ -70,5 +70,41 @@ describe("resolveConfig", () => {
 
     const result = await resolveConfig("local", { path: "/repo" });
     expect(result.error).toBeDefined();
+  });
+});
+
+describe("validateSchema", () => {
+  it("returns no errors for a valid config", () => {
+    const config = {
+      package: [{ name: "app", path: ".", versionedFiles: [{ path: "package.json", format: "json" }] }],
+    };
+    const errors = validateSchema(config);
+    expect(errors).toEqual([]);
+  });
+
+  it("returns errors for missing required fields", () => {
+    const config = {
+      package: [{ name: "app" }], // missing 'path'
+    };
+    const errors = validateSchema(config);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toMatch(/path/i);
+  });
+
+  it("returns errors for invalid enum values", () => {
+    const config = {
+      workspace: { versioning: "invalid-strategy" },
+      package: [{ name: "app", path: "." }],
+    };
+    const errors = validateSchema(config);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("returns errors for additional properties", () => {
+    const config = {
+      package: [{ name: "app", path: ".", unknownField: true }],
+    };
+    const errors = validateSchema(config);
+    expect(errors.length).toBeGreaterThan(0);
   });
 });

--- a/src/tools/__tests__/validate.test.ts
+++ b/src/tools/__tests__/validate.test.ts
@@ -1,10 +1,74 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CONFIG_FILES } from "../config.js";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+  access: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { readFile, access } from "node:fs/promises";
+const mockReadFile = vi.mocked(readFile);
+const mockAccess = vi.mocked(access);
+
+import { resolveConfig } from "../validate.js";
+
+function makeResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Not Found",
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
 
 describe("CONFIG_FILES", () => {
   it("is exported and contains expected filenames", () => {
     expect(CONFIG_FILES).toContain("ferrflow.json");
     expect(CONFIG_FILES).toContain(".ferrflow");
     expect(CONFIG_FILES.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("resolveConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves local config from first matching file", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT")); // ferrflow.json
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT")); // ferrflow.json5
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT")); // ferrflow.toml
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({ package: [{ name: "app", path: "." }] }),
+    ); // .ferrflow
+
+    const result = await resolveConfig("local", { path: "/repo" });
+    expect(result.config).toEqual({ package: [{ name: "app", path: "." }] });
+    expect(result.filename).toBe(".ferrflow");
+  });
+
+  it("returns error when no local config found", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await resolveConfig("local", { path: "/repo" });
+    expect(result.error).toMatch(/no FerrFlow configuration file found/i);
+  });
+
+  it("resolves github config via fetch", async () => {
+    const configContent = JSON.stringify({ package: [{ name: "api", path: "packages/api" }] });
+    mockFetch.mockResolvedValueOnce(makeResponse({ content: Buffer.from(configContent).toString("base64"), encoding: "base64" }));
+
+    const result = await resolveConfig("github", { owner: "org", repo: "repo" });
+    expect(result.config).toEqual({ package: [{ name: "api", path: "packages/api" }] });
+  });
+
+  it("returns error for invalid JSON", async () => {
+    mockReadFile.mockResolvedValueOnce("not valid json {{{");
+
+    const result = await resolveConfig("local", { path: "/repo" });
+    expect(result.error).toBeDefined();
   });
 });

--- a/src/tools/__tests__/validate.test.ts
+++ b/src/tools/__tests__/validate.test.ts
@@ -13,7 +13,8 @@ import { readFile, access } from "node:fs/promises";
 const mockReadFile = vi.mocked(readFile);
 const mockAccess = vi.mocked(access);
 
-import { resolveConfig, validateSchema, checkPaths } from "../validate.js";
+import { resolveConfig, validateSchema, checkPaths, registerValidateTools } from "../validate.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function makeResponse(body: unknown, status = 200): Response {
   return {
@@ -303,5 +304,84 @@ describe("checkPaths — github mode", () => {
     const result = await checkPaths(config, "github", { owner: "org", repo: "repo" });
     expect(result.errors).toEqual([]);
     expect(result.warnings).toEqual([]);
+  });
+});
+
+describe("validate_config tool", () => {
+  let toolHandler: (params: Record<string, unknown>) => Promise<unknown>;
+
+  const mockServer = {
+    tool: vi.fn((_name: string, _desc: string, _schema: unknown, handler: (params: Record<string, unknown>) => Promise<unknown>) => {
+      toolHandler = handler;
+    }),
+  } as unknown as McpServer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registerValidateTools(mockServer);
+  });
+
+  it("registers the tool with correct name", () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      "validate_config",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns valid result for correct local config", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({
+        package: [{ name: "app", path: ".", versionedFiles: [{ path: "package.json", format: "json" }] }],
+        workspace: { tagTemplate: "v{version}", orphanedTagStrategy: "warn" },
+      }),
+    );
+    mockAccess.mockResolvedValue(undefined);
+
+    const result = (await toolHandler({ source: "local", path: "/repo" })) as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.valid).toBe(true);
+  });
+
+  it("returns error when no config found", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    const result = (await toolHandler({ source: "local", path: "/repo" })) as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.errors.length).toBeGreaterThan(0);
+  });
+
+  it("returns schema errors for invalid config", async () => {
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({ package: [{ name: "app" }] }),
+    );
+
+    const result = (await toolHandler({ source: "local", path: "/repo" })) as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.errors.length).toBeGreaterThan(0);
+  });
+
+  it("rejects github mode without owner or repo", async () => {
+    const result = (await toolHandler({ source: "github" })) as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.errors[0].message).toMatch(/owner.*repo/i);
+  });
+
+  it("skips path checks when schema errors exist", async () => {
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({ package: [{ name: "app", unknownField: true }] }),
+    );
+
+    const result = (await toolHandler({ source: "local", path: "/repo" })) as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.valid).toBe(false);
+    expect(mockAccess).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { fetchRepoFile } from "./github.js";
 
-const CONFIG_FILES = [
+export const CONFIG_FILES = [
   "ferrflow.json",
   "ferrflow.json5",
   "ferrflow.toml",

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -20,12 +20,17 @@ export async function resolveConfig(
   if (source === "local") {
     const root = params.path || process.cwd();
     for (const filename of CONFIG_FILES) {
+      let raw: string;
       try {
-        const raw = await readFile(join(root, filename), "utf-8");
-        const config = parseConfig(raw, filename);
-        return { config, filename };
+        raw = await readFile(join(root, filename), "utf-8");
       } catch {
         continue;
+      }
+      try {
+        const config = parseConfig(raw, filename);
+        return { config, filename };
+      } catch (e) {
+        return { error: `Failed to parse ${filename}: ${(e as Error).message}` };
       }
     }
     return { error: "No FerrFlow configuration file found. Looked for: " + CONFIG_FILES.join(", ") };

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { readFile } from "node:fs/promises";
+import { readFile, access } from "node:fs/promises";
 import { join } from "node:path";
+import Ajv from "ajv";
+import ferrflowSchema from "../schema/ferrflow.json" with { type: "json" };
 import { CONFIG_FILES } from "./config.js";
 import { fetchRepoFile } from "./github.js";
 
@@ -42,6 +44,24 @@ export async function resolveConfig(
     }
   }
   return { error: "No FerrFlow configuration file found. Looked for: " + CONFIG_FILES.join(", ") };
+}
+
+export interface ValidationEntry {
+  path: string;
+  message: string;
+}
+
+const ajv = new Ajv({ allErrors: true });
+const schemaValidator = ajv.compile(ferrflowSchema);
+
+export function validateSchema(config: Record<string, unknown>): ValidationEntry[] {
+  const valid = schemaValidator(config);
+  if (valid) return [];
+
+  return (schemaValidator.errors || []).map((err) => ({
+    path: err.instancePath ? err.instancePath.slice(1).replace(/\//g, ".") : "(root)",
+    message: err.message || "unknown validation error",
+  }));
 }
 
 function parseConfig(raw: string, filename: string): Record<string, unknown> {

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { CONFIG_FILES } from "./config.js";
+import { fetchRepoFile } from "./github.js";
+
+interface ResolveResult {
+  config?: Record<string, unknown>;
+  filename?: string;
+  error?: string;
+}
+
+export async function resolveConfig(
+  source: string,
+  params: { path?: string; owner?: string; repo?: string; ref?: string },
+): Promise<ResolveResult> {
+  if (source === "local") {
+    const root = params.path || process.cwd();
+    for (const filename of CONFIG_FILES) {
+      try {
+        const raw = await readFile(join(root, filename), "utf-8");
+        const config = parseConfig(raw, filename);
+        return { config, filename };
+      } catch {
+        continue;
+      }
+    }
+    return { error: "No FerrFlow configuration file found. Looked for: " + CONFIG_FILES.join(", ") };
+  }
+
+  // GitHub mode
+  for (const filename of CONFIG_FILES) {
+    const content = await fetchRepoFile(params.owner!, params.repo!, filename, params.ref);
+    if (content !== null) {
+      try {
+        const config = parseConfig(content, filename);
+        return { config, filename };
+      } catch (e) {
+        return { error: `Failed to parse ${filename}: ${(e as Error).message}` };
+      }
+    }
+  }
+  return { error: "No FerrFlow configuration file found. Looked for: " + CONFIG_FILES.join(", ") };
+}
+
+function parseConfig(raw: string, filename: string): Record<string, unknown> {
+  if (filename.endsWith(".toml")) {
+    throw new Error("TOML parsing not yet supported");
+  }
+  return JSON.parse(raw);
+}

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -64,6 +64,118 @@ export function validateSchema(config: Record<string, unknown>): ValidationEntry
   }));
 }
 
+interface CheckResult {
+  errors: ValidationEntry[];
+  warnings: ValidationEntry[];
+  suggestions: ValidationEntry[];
+}
+
+interface PackageDef {
+  name: string;
+  path: string;
+  changelog?: string | null;
+  versionedFiles?: Array<{ path: string; format: string }>;
+  sharedPaths?: string[];
+}
+
+async function pathExists(filepath: string): Promise<boolean> {
+  try {
+    await access(filepath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function githubPathExists(
+  owner: string,
+  repo: string,
+  path: string,
+  ref?: string,
+): Promise<boolean> {
+  const content = await fetchRepoFile(owner, repo, path, ref);
+  return content !== null;
+}
+
+export async function checkPaths(
+  config: Record<string, unknown>,
+  source: string,
+  params: { path?: string; owner?: string; repo?: string; ref?: string },
+): Promise<CheckResult> {
+  const errors: ValidationEntry[] = [];
+  const warnings: ValidationEntry[] = [];
+  const suggestions: ValidationEntry[] = [];
+
+  const packages = (config.package || []) as PackageDef[];
+  const workspace = (config.workspace || {}) as Record<string, unknown>;
+
+  const exists = source === "local"
+    ? (p: string) => pathExists(join(params.path || process.cwd(), p))
+    : (p: string) => githubPathExists(params.owner!, params.repo!, p, params.ref);
+
+  for (let i = 0; i < packages.length; i++) {
+    const pkg = packages[i];
+    const prefix = `package[${i}]`;
+
+    if (!(await exists(pkg.path))) {
+      errors.push({ path: `${prefix}.path`, message: `directory not found: ${pkg.path}` });
+    }
+
+    if (pkg.versionedFiles) {
+      for (let j = 0; j < pkg.versionedFiles.length; j++) {
+        const vf = pkg.versionedFiles[j];
+        if (!(await exists(vf.path))) {
+          errors.push({
+            path: `${prefix}.versionedFiles[${j}].path`,
+            message: `file not found: ${vf.path}`,
+          });
+        }
+      }
+    }
+
+    if (pkg.changelog && !(await exists(pkg.changelog))) {
+      warnings.push({
+        path: `${prefix}.changelog`,
+        message: `${pkg.changelog} does not exist yet, will be created on first release`,
+      });
+    }
+
+    if (pkg.sharedPaths) {
+      for (let j = 0; j < pkg.sharedPaths.length; j++) {
+        const sp = pkg.sharedPaths[j];
+        if (!(await exists(sp))) {
+          warnings.push({
+            path: `${prefix}.sharedPaths[${j}]`,
+            message: `path not found: ${sp}`,
+          });
+        }
+      }
+    }
+
+    if (!pkg.versionedFiles || pkg.versionedFiles.length === 0) {
+      suggestions.push({
+        path: `${prefix}.versionedFiles`,
+        message: "no versionedFiles declared — version won't be written to any file",
+      });
+    }
+  }
+
+  if (!workspace.orphanedTagStrategy) {
+    suggestions.push({
+      path: "workspace.orphanedTagStrategy",
+      message: "not set, defaults to 'warn'",
+    });
+  }
+  if (!workspace.tagTemplate) {
+    suggestions.push({
+      path: "workspace.tagTemplate",
+      message: "not set, defaults to 'v{version}' (single repo) or '{name}@v{version}' (monorepo)",
+    });
+  }
+
+  return { errors, warnings, suggestions };
+}
+
 function parseConfig(raw: string, filename: string): Record<string, unknown> {
   if (filename.endsWith(".toml")) {
     throw new Error("TOML parsing not yet supported");

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -176,6 +176,69 @@ export async function checkPaths(
   return { errors, warnings, suggestions };
 }
 
+interface ValidationResponse {
+  valid: boolean;
+  errors?: ValidationEntry[];
+  warnings?: ValidationEntry[];
+  suggestions?: ValidationEntry[];
+}
+
+function formatResponse(result: ValidationResponse) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}
+
+export function registerValidateTools(server: McpServer) {
+  server.tool(
+    "validate_config",
+    "Validate a FerrFlow configuration file against the JSON schema and check that referenced paths exist. Supports local repositories and GitHub repositories.",
+    {
+      source: z.enum(["local", "github"]).describe("Where to read the config from"),
+      path: z.string().optional().describe("Local path to the repository root (local mode, defaults to cwd)"),
+      owner: z.string().optional().describe("GitHub repository owner (required for github mode)"),
+      repo: z.string().optional().describe("GitHub repository name (required for github mode)"),
+      ref: z.string().optional().describe("Git ref — branch, tag, or commit SHA (github mode, defaults to default branch)"),
+    },
+    async ({ source, path, owner, repo, ref }) => {
+      if (source === "github" && (!owner || !repo)) {
+        return formatResponse({
+          valid: false,
+          errors: [{ path: "(params)", message: "owner and repo are required for github mode" }],
+        });
+      }
+
+      const resolved = await resolveConfig(source, { path, owner, repo, ref });
+      if (resolved.error) {
+        return formatResponse({
+          valid: false,
+          errors: [{ path: "(config)", message: resolved.error }],
+        });
+      }
+
+      const schemaErrors = validateSchema(resolved.config!);
+      if (schemaErrors.length > 0) {
+        return formatResponse({ valid: false, errors: schemaErrors });
+      }
+
+      const checks = await checkPaths(resolved.config!, source, { path, owner, repo, ref });
+      const valid = checks.errors.length === 0;
+
+      return formatResponse({
+        valid,
+        ...(checks.errors.length > 0 && { errors: checks.errors }),
+        ...(checks.warnings.length > 0 && { warnings: checks.warnings }),
+        ...(checks.suggestions.length > 0 && { suggestions: checks.suggestions }),
+      });
+    },
+  );
+}
+
 function parseConfig(raw: string, filename: string): Record<string, unknown> {
   if (filename.endsWith(".toml")) {
     throw new Error("TOML parsing not yet supported");


### PR DESCRIPTION
## Summary

- Add `validate_config` MCP tool that validates FerrFlow configuration files against the JSON schema and checks that referenced paths exist
- Supports both local repositories (`source: "local"`) and GitHub repositories (`source: "github"`) with path existence checks via filesystem or GitHub API
- Three-stage validation pipeline: config resolution, Ajv schema validation, path & semantic checks with structured errors/warnings/suggestions output

Closes #61

## Test Plan

- [ ] Run `pnpm test` — 91 tests passing (27 new for validate tool)
- [ ] Run `pnpm typecheck` — no type errors
- [ ] Run `pnpm build` — compiles successfully
- [ ] Verify validate_config tool appears when connecting MCP server