### PR TITLE
chore(ci): bump FerrFlow action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.FERRFLOW_TOKEN }}
-      - uses: FerrFlow-Org/ferrflow@v2
+      - uses: FerrFlow-Org/ferrflow@v3
         with:
           dry_run: ${{ inputs.dry_run }}
         env:


### PR DESCRIPTION
One-line bump of the release step to `FerrFlow-Org/ferrflow@v3` to pick up the version-source-of-truth fix and the first-release bootstrap shipped in ferrflow v3.0.2+.