### PR TITLE
fix(ci): rebrand GHCR + GitHub URLs from ferrflow-org to ferrlabs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.FERRFLOW_TOKEN }}
-      - uses: FerrFlow-Org/ferrflow@v4
+      - uses: FerrLabs/ferrflow@v4
         with:
           dry_run: ${{ inputs.dry_run }}
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,11 +60,11 @@ fix: handle missing token gracefully
 
 ## Reporting Bugs
 
-Use the [bug report template](https://github.com/FerrFlow-Org/MCP/issues/new?template=bug_report.md).
+Use the [bug report template](https://github.com/FerrLabs/MCP/issues/new?template=bug_report.md).
 
 ## Requesting Features
 
-Use the [feature request template](https://github.com/FerrFlow-Org/MCP/issues/new?template=feature_request.md).
+Use the [feature request template](https://github.com/FerrLabs/MCP/issues/new?template=feature_request.md).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # FerrFlow MCP Server
 
-[![CI](https://github.com/FerrFlow-Org/MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/FerrFlow-Org/MCP/actions/workflows/ci.yml)
+[![CI](https://github.com/FerrLabs/MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/FerrLabs/MCP/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@ferrflow/mcp)](https://www.npmjs.com/package/@ferrflow/mcp)
-[![Coverage](https://codecov.io/gh/FerrFlow-Org/MCP/branch/main/graph/badge.svg)](https://codecov.io/gh/FerrFlow-Org/MCP)
-[![License](https://img.shields.io/github/license/FerrFlow-Org/MCP)](LICENSE)
+[![Coverage](https://codecov.io/gh/FerrLabs/MCP/branch/main/graph/badge.svg)](https://codecov.io/gh/FerrLabs/MCP)
+[![License](https://img.shields.io/github/license/FerrLabs/MCP)](LICENSE)
 [![Socket Badge](https://badge.socket.dev/npm/package/@ferrflow/mcp/latest)](https://badge.socket.dev/npm/package/@ferrflow/mcp/latest)
 [![Known Vulnerabilities](https://snyk.io/test/npm/@ferrflow/mcp/badge.svg)](https://snyk.io/test/npm/@ferrflow/mcp)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Only the latest release receives security updates.
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/FerrFlow-Org/MCP/security/advisories/new).
+If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/FerrLabs/MCP/security/advisories/new).
 
 Do **not** open a public issue for security vulnerabilities.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/FerrFlow-Org/MCP.git"
+    "url": "https://github.com/FerrLabs/MCP.git"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Bulk URL update: `ferrflow-org/` → `ferrlabs/`, `FerrFlow-Org/` → `FerrLabs/`. Skips CHANGELOG and lockfiles. Mirrors [FerrFlow-Cloud#376](https://github.com/FerrLabs/FerrFlow-Cloud/pull/376).