### PR TITLE
ci: switch to ferrlabs-k8s self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
@@ -40,7 +40,7 @@ jobs:
   release:
     name: Release
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.test.result == 'success') || (github.event_name == 'workflow_dispatch' && needs.test.result == 'success')
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish-npm:
     name: Publish npm
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Aligns MCP with the rest of the FerrLabs org — CI now runs on the self-hosted K8s runner instead of `ubuntu-latest`. Replaces 3 `runs-on` entries across `ci.yml` and `release.yml`.