### PR TITLE
fix(ci): downgrade pnpm action v6 -> v5 with pinned version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
       - uses: actions/setup-node@v6


### PR DESCRIPTION
v6 fails with npm ENOENT on ferrlabs-k8s runner