### PR TITLE
fix(ci): release.yml pnpm action v6->v5 + FERRFLOW_TOKEN fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.FERRFLOW_TOKEN }}
+          token: ${{ secrets.FERRFLOW_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: FerrLabs/ferrflow@v4
         with:
           dry_run: ${{ inputs.dry_run }}
         env:
-          GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Apply the same fixes to release.yml that ci.yml got in #93.