### PR TITLE
docs(readme): drop CI badge and swap dead snyk for openssf scorecard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.FERRFLOW_TOKEN }}
+          token: ${{ secrets.FERRFLOW_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: FerrLabs/ferrflow@v4
         with:
           dry_run: ${{ inputs.dry_run }}
         env:
-          GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
       - uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # FerrFlow MCP Server
 
-[![CI](https://github.com/FerrLabs/MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/FerrLabs/MCP/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@ferrflow/mcp)](https://www.npmjs.com/package/@ferrflow/mcp)
 [![Coverage](https://codecov.io/gh/FerrLabs/MCP/branch/main/graph/badge.svg)](https://codecov.io/gh/FerrLabs/MCP)
 [![License](https://img.shields.io/github/license/FerrLabs/MCP)](LICENSE)
 [![Socket Badge](https://badge.socket.dev/npm/package/@ferrflow/mcp/latest)](https://badge.socket.dev/npm/package/@ferrflow/mcp/latest)
-[![Known Vulnerabilities](https://snyk.io/test/npm/@ferrflow/mcp/badge.svg)](https://snyk.io/test/npm/@ferrflow/mcp)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/FerrLabs/MCP/badge)](https://scorecard.dev/viewer/?uri=github.com/FerrLabs/MCP)
 
 [Model Context Protocol](https://modelcontextprotocol.io) server that lets AI assistants interact with FerrFlow. Runs locally via stdio transport.
 


### PR DESCRIPTION
Drop workflow status badges from README (noise, not useful for consumers).