### PR TITLE
docs(readme): drop openssf scorecard badge (private repo, not indexable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Coverage](https://codecov.io/gh/FerrLabs/MCP/branch/main/graph/badge.svg)](https://codecov.io/gh/FerrLabs/MCP)
 [![License](https://img.shields.io/github/license/FerrLabs/MCP)](LICENSE)
 [![Socket Badge](https://badge.socket.dev/npm/package/@ferrflow/mcp/latest)](https://badge.socket.dev/npm/package/@ferrflow/mcp/latest)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/FerrLabs/MCP/badge)](https://scorecard.dev/viewer/?uri=github.com/FerrLabs/MCP)
 
 [Model Context Protocol](https://modelcontextprotocol.io) server that lets AI assistants interact with FerrFlow. Runs locally via stdio transport.
 


### PR DESCRIPTION
scorecard.dev cannot inspect private repos, so the badge renders as "invalid repo path". Removing it from the README; Socket, License, Coverage, and npm badges remain.