### PR TITLE
ci: normalize FerrFlow action casing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: FerrLabs/ferrflow@v4
+      - uses: FerrLabs/FerrFlow@v4
         with:
           dry_run: ${{ inputs.dry_run }}
           bot: true


### PR DESCRIPTION
Lowercase `FerrLabs/ferrflow` → canonical `FerrLabs/FerrFlow` to match the rest of the org.