### PR TITLE
chore(deps): switch from Renovate to Dependabot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>FerrLabs/.github"]
-}


### PR DESCRIPTION
Switching the org from Renovate to Dependabot for dependency updates.

This PR:
- Removes `renovate.json` from the repo.
- Adds `.github/dependabot.yml` with weekly grouped updates for the ecosystems present in this repo (github-actions, npm, cargo, docker — whichever applies).

Patch + minor updates are grouped per ecosystem to keep PR volume manageable.