### PR TITLE
chore(workflows): migrate ubuntu-latest to ferrlabs-k8s

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:


### PR DESCRIPTION
Migrate every direct `runs-on: ubuntu-latest` to `runs-on: ferrlabs-k8s` (self-hosted Kubernetes runner) to stop burning GitHub Actions billing on private repos.

Matrix entries (`os: ubuntu-latest`) and `if: matrix.os == 'ubuntu-latest'` lines are intentionally preserved where present — they drive cross-compilation OS targets, not runner selection. Lines using `${{ inputs.runner }}` are also untouched (consumers pass `ferrlabs-k8s` already).

After merge, re-run failed CI on existing PRs via `gh run rerun --failed`.
