### PR TITLE
chore(hooks): mirror CI checks in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,1 @@
-pnpm typecheck
-pnpm build
-pnpm test
+pnpm ci:local

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "ci:local": "pnpm typecheck && pnpm test && pnpm build",
     "dev": "tsx watch src/index.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Summary

Adds a `ci:local` npm script and points `.husky/pre-push` at it so `git push` runs the same checks as `.github/workflows/ci.yml`.

`pnpm ci:local` runs:
- `pnpm typecheck` (mirrors `Typecheck` step)
- `pnpm test` (mirrors `Test with coverage` minus the codecov upload)
- `pnpm build` (mirrors `Build` step)

Coverage upload is CI-only. No new dev deps.

## Test plan
- [ ] `pnpm ci:local` passes on a clean checkout
- [ ] `git push --dry-run` does not crash