### PR TITLE
feat(auth): OAuth 2.0 loopback PKCE flow + token persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `mcp` will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Features
+
+- feat(auth): OAuth 2.0 loopback PKCE flow on first authenticated tool call — the MCP opens `auth.ferrlabs.com` in the user's browser, captures the callback on a loopback port, and persists the token. No more manual `FERRLABS_API_TOKEN` paste for desktop users (#113)
+- feat(auth): token persistence per OS conventions (`%APPDATA%\ferrlabs\mcp\token.json` on Windows, `~/.config/ferrlabs/mcp/token.json` on Linux, `~/Library/Application Support/...` on macOS). File mode `0600` on Unix.
+- feat(auth): new env knobs — `FERRLABS_AUTH_URL` (override auth host), `FERRLABS_MCP_NO_OAUTH=1` (disable OAuth fallback for CI), `FERRLABS_MCP_TOKEN_PATH` (override persistence path), `FERRLABS_MCP_NO_PERSIST=1` (in-memory only)
+- `FERRLABS_API_TOKEN` still works and short-circuits the OAuth dance — safe to keep in CI configs
+
 ## [5.0.0] - 2026-05-19
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -15,16 +15,31 @@ Add to your MCP client configuration (Claude Code, Cursor, etc.):
   "mcpServers": {
     "ferrlabs": {
       "command": "npx",
-      "args": ["-y", "@ferrlabs/mcp"],
-      "env": {
-        "FERRLABS_API_TOKEN": "fl_..."
-      }
+      "args": ["-y", "@ferrlabs/mcp"]
     }
   }
 }
 ```
 
-Create a token from `app.ferrlabs.com` (Settings → API Tokens) and assign the scopes you want the assistant to have. The token is forwarded as `x-api-token` to `api.ferrlabs.com`.
+The first time you call a tool that needs auth, the MCP opens `auth.ferrlabs.com` in your default browser (OAuth 2.0 loopback PKCE). After you click Allow, the token is saved locally and reused for future sessions. No env var required.
+
+### CI / scripted / headless use
+
+Bypass the browser dance by injecting a token directly:
+
+```json
+{
+  "mcpServers": {
+    "ferrlabs": {
+      "command": "npx",
+      "args": ["-y", "@ferrlabs/mcp"],
+      "env": { "FERRLABS_API_TOKEN": "fl_..." }
+    }
+  }
+}
+```
+
+Create the token from `app.ferrlabs.com` → Settings → API Tokens. It's forwarded as `x-api-token` to `api.ferrlabs.com`.
 
 ## Available Tools
 
@@ -55,11 +70,26 @@ FerrFlow CLI-specific tools (`dry_run`, `validate_config`, `read_config`, `read_
 
 ## Configuration
 
-| Variable             | Description                                                                  | Default                    |
-| -------------------- | ---------------------------------------------------------------------------- | -------------------------- |
-| `API_URL`            | FerrLabs API base URL (no `/v1` suffix — paths are prefixed in code)         | `https://api.ferrlabs.com` |
-| `FERRLABS_API_TOKEN` | FerrLabs API token (required for authenticated tools)                        | —                          |
-| `FERRFLOW_API_TOKEN` | **Deprecated** — accepted as a fallback for backward compatibility with v3.x | —                          |
+| Variable                  | Description                                                                           | Default                                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `API_URL`                 | FerrLabs API base URL (no `/v1` suffix — paths are prefixed in code)                  | `https://api.ferrlabs.com`                                                |
+| `FERRLABS_AUTH_URL`       | Auth SPA base URL (where the OAuth browser flow lands)                                | `https://auth.ferrlabs.com`                                               |
+| `FERRLABS_API_TOKEN`      | Pre-provisioned token. Bypasses the OAuth flow. Use for CI / scripted environments.   | —                                                                         |
+| `FERRFLOW_API_TOKEN`      | **Deprecated** — accepted as a fallback for backward compatibility with v3.x.         | —                                                                         |
+| `FERRLABS_MCP_NO_OAUTH`   | Set to `1` to disable the OAuth fallback. Then `FERRLABS_API_TOKEN` becomes required. | unset                                                                     |
+| `FERRLABS_MCP_TOKEN_PATH` | Override the path where the OAuth-acquired token is persisted.                        | `%APPDATA%\ferrlabs\mcp\token.json` / `~/.config/ferrlabs/mcp/token.json` |
+| `FERRLABS_MCP_NO_PERSIST` | Set to `1` to keep the token in memory only (re-auth on every cold start).            | unset                                                                     |
+
+### How auth resolution works
+
+On the first authenticated tool call, the MCP looks for a token in this order:
+
+1. In-memory cache (set during this MCP process's lifetime)
+2. `FERRLABS_API_TOKEN` (or `FERRFLOW_API_TOKEN`) env var
+3. Persisted token file (`FERRLABS_MCP_TOKEN_PATH`)
+4. **OAuth 2.0 loopback PKCE flow** — opens the user's browser, captures the callback on `http://127.0.0.1:54321/cb`, exchanges the code for a session token via `POST /v1/auth/exchange`. Token is persisted to step 3 for future sessions.
+
+If you set `FERRLABS_MCP_NO_OAUTH=1`, step 4 is skipped — useful for CI where opening a browser would hang.
 
 ## Smoke test
 

--- a/src/auth/__tests__/index.test.ts
+++ b/src/auth/__tests__/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('getToken', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.FERRLABS_API_TOKEN;
+    delete process.env.FERRFLOW_API_TOKEN;
+    delete process.env.FERRLABS_MCP_NO_OAUTH;
+    process.env.FERRLABS_MCP_NO_PERSIST = '1';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns FERRLABS_API_TOKEN when set, without touching persistence or OAuth', async () => {
+    process.env.FERRLABS_API_TOKEN = 'fl_env_token';
+    const { getToken } = await import('../index.js');
+    expect(await getToken()).toBe('fl_env_token');
+  });
+
+  it('falls back to FERRFLOW_API_TOKEN (legacy compat)', async () => {
+    process.env.FERRFLOW_API_TOKEN = 'fl_legacy_token';
+    const { getToken } = await import('../index.js');
+    expect(await getToken()).toBe('fl_legacy_token');
+  });
+
+  it('throws when no token and FERRLABS_MCP_NO_OAUTH=1', async () => {
+    process.env.FERRLABS_MCP_NO_OAUTH = '1';
+    const { getToken } = await import('../index.js');
+    await expect(getToken()).rejects.toThrow(/FERRLABS_API_TOKEN environment variable is required/);
+  });
+
+  it('caches the token across calls (env path)', async () => {
+    process.env.FERRLABS_API_TOKEN = 'fl_cached';
+    const { getToken } = await import('../index.js');
+    const a = await getToken();
+    process.env.FERRLABS_API_TOKEN = 'fl_changed';
+    const b = await getToken();
+    expect(a).toBe(b);
+    expect(a).toBe('fl_cached');
+  });
+});

--- a/src/auth/__tests__/oauth.test.ts
+++ b/src/auth/__tests__/oauth.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { generatePkcePair } from '../oauth.js';
+import { createHash } from 'node:crypto';
+
+describe('generatePkcePair', () => {
+  it('returns a verifier between 43 and 128 chars (RFC 7636)', () => {
+    const { verifier } = generatePkcePair();
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+  });
+
+  it('returns a challenge that is SHA-256(verifier) base64url-encoded', () => {
+    const { verifier, challenge } = generatePkcePair();
+    const expected = createHash('sha256').update(verifier).digest('base64url');
+    expect(challenge).toBe(expected);
+  });
+
+  it('returns different verifier+challenge pairs each call', () => {
+    const a = generatePkcePair();
+    const b = generatePkcePair();
+    expect(a.verifier).not.toBe(b.verifier);
+    expect(a.challenge).not.toBe(b.challenge);
+  });
+
+  it('returns base64url-encoded values (no +, /, =)', () => {
+    const { verifier, challenge } = generatePkcePair();
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+});

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,44 @@
+import { readPersistedToken, writePersistedToken } from './persistence.js';
+import { runLoopbackOauthFlow } from './oauth.js';
+
+let cached: string | null = null;
+let inFlight: Promise<string> | null = null;
+
+export async function getToken(): Promise<string> {
+  if (cached) return cached;
+
+  const envToken = process.env.FERRLABS_API_TOKEN ?? process.env.FERRFLOW_API_TOKEN;
+  if (envToken) {
+    cached = envToken;
+    return envToken;
+  }
+
+  const persisted = await readPersistedToken();
+  if (persisted) {
+    cached = persisted;
+    return persisted;
+  }
+
+  if (process.env.FERRLABS_MCP_NO_OAUTH === '1') {
+    throw new Error(
+      'FERRLABS_API_TOKEN environment variable is required (FERRLABS_MCP_NO_OAUTH=1 disables the OAuth fallback).',
+    );
+  }
+
+  if (!inFlight) {
+    inFlight = (async () => {
+      const { token } = await runLoopbackOauthFlow();
+      await writePersistedToken(token);
+      cached = token;
+      return token;
+    })().finally(() => {
+      inFlight = null;
+    });
+  }
+  return inFlight;
+}
+
+export function resetTokenCacheForTesting(): void {
+  cached = null;
+  inFlight = null;
+}

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,0 +1,165 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { spawn } from 'node:child_process';
+import { platform } from 'node:os';
+
+const AUTH_BASE = process.env.FERRLABS_AUTH_URL ?? 'https://auth.ferrlabs.com';
+const API_BASE = process.env.API_URL ?? 'https://api.ferrlabs.com';
+const CLIENT_ID = 'mcp';
+const REDIRECT_PORTS = [54321, 54322] as const;
+const AUTH_TIMEOUT_MS = 2 * 60 * 1000;
+
+interface PkcePair {
+  verifier: string;
+  challenge: string;
+}
+
+export function generatePkcePair(): PkcePair {
+  const verifier = randomBytes(64).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+function generateState(): string {
+  return randomBytes(16).toString('base64url');
+}
+
+function openBrowser(url: string): void {
+  const args: { cmd: string; args: string[] } = (() => {
+    switch (platform()) {
+      case 'win32':
+        return { cmd: 'cmd', args: ['/c', 'start', '""', url] };
+      case 'darwin':
+        return { cmd: 'open', args: [url] };
+      default:
+        return { cmd: 'xdg-open', args: [url] };
+    }
+  })();
+  const child = spawn(args.cmd, args.args, { detached: true, stdio: 'ignore' });
+  child.on('error', () => {
+    // ignore — caller will time out and surface the URL via error
+  });
+  child.unref();
+}
+
+interface CallbackResult {
+  code: string;
+  state: string;
+}
+
+function listenForCallback(port: number, expectedState: string): Promise<CallbackResult> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      try {
+        const url = new URL(req.url ?? '/', `http://127.0.0.1:${port}`);
+        if (url.pathname !== '/cb') {
+          res.writeHead(404).end('Not found');
+          return;
+        }
+        const code = url.searchParams.get('code');
+        const state = url.searchParams.get('state');
+        if (!code || !state) {
+          res.writeHead(400).end('Missing code or state');
+          return;
+        }
+        if (state !== expectedState) {
+          res.writeHead(400).end('state mismatch');
+          reject(new Error('OAuth callback state mismatch (CSRF protection triggered)'));
+          server.close();
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', Connection: 'close' });
+        res.end(
+          "<!doctype html><html><body style='font-family:sans-serif;padding:2rem;color:#1e293b'><h1>Authorized</h1><p>You can close this tab and return to your terminal.</p></body></html>",
+        );
+        setImmediate(() => server.close());
+        resolve({ code, state });
+      } catch (err) {
+        res.writeHead(500).end('Internal error');
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    server.on('error', reject);
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+async function exchangeCodeForToken(
+  code: string,
+  codeVerifier: string,
+  redirectUri: string,
+): Promise<string> {
+  const res = await fetch(`${API_BASE}/v1/auth/exchange`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': 'ferrlabs-mcp/oauth' },
+    body: JSON.stringify({
+      code,
+      client_id: CLIENT_ID,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+    }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
+    throw new Error(
+      `OAuth exchange failed (HTTP ${res.status}): ${body.error ?? body.message ?? 'unknown'}`,
+    );
+  }
+  const data = (await res.json()) as { token?: string };
+  if (!data.token) throw new Error('OAuth exchange returned no token');
+  return data.token;
+}
+
+export interface RunLoopbackFlowResult {
+  token: string;
+  scope?: string;
+}
+
+export async function runLoopbackOauthFlow(): Promise<RunLoopbackFlowResult> {
+  const pkce = generatePkcePair();
+  const state = generateState();
+
+  let port: number | null = null;
+  let callbackPromise: Promise<CallbackResult> | null = null;
+  for (const candidate of REDIRECT_PORTS) {
+    try {
+      callbackPromise = listenForCallback(candidate, state);
+      port = candidate;
+      break;
+    } catch {
+      callbackPromise = null;
+    }
+  }
+  if (port === null || !callbackPromise) {
+    throw new Error(
+      `Could not bind any of the loopback ports (${REDIRECT_PORTS.join(', ')}). Close whatever is using them and retry.`,
+    );
+  }
+
+  const redirectUri = `http://127.0.0.1:${port}/cb`;
+  const authorizeUrl = new URL(`${AUTH_BASE}/authorize`);
+  authorizeUrl.searchParams.set('client_id', CLIENT_ID);
+  authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+  authorizeUrl.searchParams.set('response_type', 'code');
+  authorizeUrl.searchParams.set('code_challenge', pkce.challenge);
+  authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+  authorizeUrl.searchParams.set('state', state);
+
+  openBrowser(authorizeUrl.toString());
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(
+      () =>
+        reject(
+          new Error(
+            `OAuth flow timed out after ${AUTH_TIMEOUT_MS / 1000}s. If your browser didn't open, visit: ${authorizeUrl.toString()}`,
+          ),
+        ),
+      AUTH_TIMEOUT_MS,
+    );
+  });
+
+  const { code } = await Promise.race([callbackPromise, timeoutPromise]);
+  const token = await exchangeCodeForToken(code, pkce.verifier, redirectUri);
+  return { token };
+}

--- a/src/auth/persistence.ts
+++ b/src/auth/persistence.ts
@@ -1,0 +1,76 @@
+import { mkdir, readFile, writeFile, chmod } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { homedir, platform } from 'node:os';
+
+interface PersistedToken {
+  token: string;
+  obtained_at: string;
+  scopes?: string[];
+}
+
+function defaultTokenPath(): string {
+  const override = process.env.FERRLABS_MCP_TOKEN_PATH;
+  if (override) return override;
+
+  const home = homedir();
+  switch (platform()) {
+    case 'win32':
+      return join(
+        process.env.APPDATA ?? join(home, 'AppData', 'Roaming'),
+        'ferrlabs',
+        'mcp',
+        'token.json',
+      );
+    case 'darwin':
+      return join(home, 'Library', 'Application Support', 'ferrlabs', 'mcp', 'token.json');
+    default:
+      return join(
+        process.env.XDG_CONFIG_HOME ?? join(home, '.config'),
+        'ferrlabs',
+        'mcp',
+        'token.json',
+      );
+  }
+}
+
+export async function readPersistedToken(): Promise<string | null> {
+  if (process.env.FERRLABS_MCP_NO_PERSIST === '1') return null;
+  try {
+    const raw = await readFile(defaultTokenPath(), 'utf8');
+    const parsed = JSON.parse(raw) as PersistedToken;
+    if (typeof parsed.token === 'string' && parsed.token.length > 0) {
+      return parsed.token;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writePersistedToken(token: string, scopes?: string[]): Promise<void> {
+  if (process.env.FERRLABS_MCP_NO_PERSIST === '1') return;
+  const path = defaultTokenPath();
+  await mkdir(dirname(path), { recursive: true });
+  const payload: PersistedToken = {
+    token,
+    obtained_at: new Date().toISOString(),
+    scopes,
+  };
+  await writeFile(path, JSON.stringify(payload, null, 2), 'utf8');
+  if (platform() !== 'win32') {
+    try {
+      await chmod(path, 0o600);
+    } catch {
+      // ignore — best effort on platforms that don't support POSIX modes
+    }
+  }
+}
+
+export async function clearPersistedToken(): Promise<void> {
+  const { unlink } = await import('node:fs/promises');
+  try {
+    await unlink(defaultTokenPath());
+  } catch {
+    // ignore
+  }
+}

--- a/src/tools/issues.ts
+++ b/src/tools/issues.ts
@@ -1,17 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiRequest } from './api-client.js';
-
-const API_TOKEN = process.env.FERRLABS_API_TOKEN ?? process.env.FERRFLOW_API_TOKEN;
-
-function requireToken(): string {
-  if (!API_TOKEN) {
-    throw new Error(
-      'FERRLABS_API_TOKEN environment variable is required for authenticated operations.',
-    );
-  }
-  return API_TOKEN;
-}
+import { getToken } from '../auth/index.js';
 
 interface IssueWithDetails {
   id: string;
@@ -48,7 +38,7 @@ export function registerIssuesTools(server: McpServer) {
         .describe('Items per page (default 25, max 100)'),
     },
     async ({ org_slug, project_slug, page, per_page }) => {
-      const token = requireToken();
+      const token = await getToken();
       const params = new URLSearchParams();
       if (page !== undefined) params.set('page', String(page));
       if (per_page !== undefined) params.set('per_page', String(per_page));

--- a/src/tools/orgs.ts
+++ b/src/tools/orgs.ts
@@ -1,17 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiRequest } from './api-client.js';
-
-const API_TOKEN = process.env.FERRLABS_API_TOKEN ?? process.env.FERRFLOW_API_TOKEN;
-
-function requireToken(): string {
-  if (!API_TOKEN) {
-    throw new Error(
-      'FERRLABS_API_TOKEN environment variable is required for authenticated operations.',
-    );
-  }
-  return API_TOKEN;
-}
+import { getToken } from '../auth/index.js';
 
 interface OrgWithMemberCount {
   id: string;
@@ -36,7 +26,7 @@ export function registerOrgsTools(server: McpServer) {
     'List FerrLabs organizations the authenticated user belongs to',
     {},
     async () => {
-      const token = requireToken();
+      const token = await getToken();
       const orgs = await apiRequest<OrgWithMemberCount[]>('/v1/orgs', { token });
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(orgs, null, 2) }],
@@ -51,7 +41,7 @@ export function registerOrgsTools(server: McpServer) {
       org_slug: z.string().min(1).describe('Organization slug (from list_orgs)'),
     },
     async ({ org_slug }) => {
-      const token = requireToken();
+      const token = await getToken();
       const projects = await apiRequest<ProjectWithCounts[]>(
         `/v1/orgs/${encodeURIComponent(org_slug)}/projects`,
         { token },

--- a/src/tools/subscriptions.ts
+++ b/src/tools/subscriptions.ts
@@ -1,17 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiRequest } from './api-client.js';
-
-const API_TOKEN = process.env.FERRLABS_API_TOKEN ?? process.env.FERRFLOW_API_TOKEN;
-
-function requireToken(): string {
-  if (!API_TOKEN) {
-    throw new Error(
-      'FERRLABS_API_TOKEN environment variable is required for authenticated operations.',
-    );
-  }
-  return API_TOKEN;
-}
+import { getToken } from '../auth/index.js';
 
 interface SubscriptionRow {
   id: string;
@@ -33,7 +23,7 @@ export function registerSubscriptionsTools(server: McpServer) {
       org_slug: z.string().min(1).describe('Organization slug'),
     },
     async ({ org_slug }) => {
-      const token = requireToken();
+      const token = await getToken();
       const subs = await apiRequest<SubscriptionRow[]>(
         `/v1/orgs/${encodeURIComponent(org_slug)}/subscriptions`,
         { token },

--- a/src/tools/tokens.ts
+++ b/src/tools/tokens.ts
@@ -1,17 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiRequest } from './api-client.js';
-
-const API_TOKEN = process.env.FERRLABS_API_TOKEN ?? process.env.FERRFLOW_API_TOKEN;
-
-function requireToken(): string {
-  if (!API_TOKEN) {
-    throw new Error(
-      'FERRLABS_API_TOKEN environment variable is required for authenticated operations (FERRFLOW_API_TOKEN is accepted as a fallback for backward compatibility).',
-    );
-  }
-  return API_TOKEN;
-}
+import { getToken } from '../auth/index.js';
 
 interface UserProfile {
   id: string;
@@ -39,7 +29,7 @@ type CreateTokenResponse = ApiTokenResponse & {
 
 export function registerTokenTools(server: McpServer) {
   server.tool('get_me', 'Get the current authenticated FerrLabs user profile', {}, async () => {
-    const token = requireToken();
+    const token = await getToken();
     const user = await apiRequest<UserProfile>('/v1/auth/me', { token });
     return {
       content: [
@@ -52,7 +42,7 @@ export function registerTokenTools(server: McpServer) {
   });
 
   server.tool('list_tokens', 'List all API tokens for the authenticated user', {}, async () => {
-    const token = requireToken();
+    const token = await getToken();
     const tokens = await apiRequest<ApiTokenResponse[]>('/v1/auth/tokens', { token });
     return {
       content: [
@@ -73,7 +63,7 @@ export function registerTokenTools(server: McpServer) {
       expires_at: z.string().optional().describe('Expiration date (ISO 8601)'),
     },
     async ({ name, scopes, expires_at }) => {
-      const token = requireToken();
+      const token = await getToken();
       const result = await apiRequest<CreateTokenResponse>('/v1/auth/tokens', {
         method: 'POST',
         body: { name, scopes, expires_at },
@@ -98,7 +88,7 @@ export function registerTokenTools(server: McpServer) {
       token_id: z.string().uuid().describe('Token ID to revoke'),
     },
     async ({ token_id }) => {
-      const token = requireToken();
+      const token = await getToken();
       await apiRequest<{ message: string }>(`/v1/auth/tokens/${token_id}`, {
         method: 'DELETE',
         token,

--- a/src/tools/vaults.ts
+++ b/src/tools/vaults.ts
@@ -1,17 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiRequest } from './api-client.js';
-
-const API_TOKEN = process.env.FERRLABS_API_TOKEN ?? process.env.FERRFLOW_API_TOKEN;
-
-function requireToken(): string {
-  if (!API_TOKEN) {
-    throw new Error(
-      'FERRLABS_API_TOKEN environment variable is required for authenticated operations.',
-    );
-  }
-  return API_TOKEN;
-}
+import { getToken } from '../auth/index.js';
 
 interface VaultWithStats {
   id: string;
@@ -31,7 +21,7 @@ export function registerVaultsTools(server: McpServer) {
       project_slug: z.string().min(1).describe('Project slug'),
     },
     async ({ org_slug, project_slug }) => {
-      const token = requireToken();
+      const token = await getToken();
       const vaults = await apiRequest<VaultWithStats[]>(
         `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/vaults`,
         { token },


### PR DESCRIPTION
Closes #113. Depends on [FerrLabs/FerrLabs-Cloud#327](https://github.com/FerrLabs/FerrLabs-Cloud/pull/327) — must ship & deploy first.

## What

Replace the manual \`FERRLABS_API_TOKEN\` paste-the-env-var dance with a real OAuth flow that matches every other modern CLI (\`gh auth login\`, \`aws sso login\`, \`vercel login\`, \`claude\`).

### First-run UX

User adds the MCP to their Claude Code config with **no env vars**:

\`\`\`json
{
  "mcpServers": {
    "ferrlabs": { "command": "npx", "args": ["-y", "@ferrlabs/mcp"] }
  }
}
\`\`\`

On the first authenticated tool call:

1. MCP generates a PKCE pair (\`code_verifier\` 64-byte base64url, \`code_challenge\` = SHA-256, base64url)
2. Spawns an HTTP server on \`127.0.0.1:54321\` (or 54322 fallback)
3. Opens \`auth.ferrlabs.com/authorize?client_id=mcp&redirect_uri=http://127.0.0.1:54321/cb&code_challenge=...&code_challenge_method=S256&state=...\` in the user's default browser via \`start\` (Windows) / \`open\` (macOS) / \`xdg-open\` (Linux)
4. User clicks Allow on the existing FerrLabs consent screen
5. Browser redirects to the loopback URL with \`?code=...&state=...\`
6. MCP validates \`state\` (CSRF), POSTs \`/v1/auth/exchange { code, code_verifier, client_id: 'mcp' }\` to swap for a session token
7. Token persisted to \`%APPDATA%\ferrlabs\mcp\token.json\` (Windows) / \`~/.config/ferrlabs/mcp/token.json\` (Linux, mode 0600) / \`~/Library/Application Support/ferrlabs/mcp/token.json\` (macOS)
8. Tool call resumes normally

Next startup → step 7 file is read straight away, no browser dance.

## Architecture

\`\`\`
src/auth/
├── index.ts         # getToken() — public API, resolution order
├── oauth.ts         # PKCE pair + loopback server + browser launch + token exchange
├── persistence.ts   # Cross-platform token read/write with proper FS perms
└── __tests__/
    ├── index.test.ts    # Resolution order (env > persisted > OAuth)
    └── oauth.test.ts    # PKCE crypto (RFC 7636 conformance)
\`\`\`

\`getToken()\` resolution order:

1. In-memory cache (per MCP process)
2. \`FERRLABS_API_TOKEN\` or \`FERRFLOW_API_TOKEN\` env (CI / scripted use)
3. Persisted token file
4. OAuth loopback flow (skipped if \`FERRLABS_MCP_NO_OAUTH=1\`)

All 12 tools use \`await getToken()\` instead of the old \`requireToken()\`. Net diff in each tool file: small.

## Backward compatibility

- \`FERRLABS_API_TOKEN\` (and \`FERRFLOW_API_TOKEN\`) still short-circuit everything. **No existing CI config breaks.**
- New flow is purely additive — only triggers when no env token AND no persisted token exist.
- \`FERRLABS_MCP_NO_OAUTH=1\` explicitly disables OAuth for headless contexts that don't want a hanging browser-open call.

## Test plan

- [x] Unit tests for PKCE pair generation (RFC 7636 verifier length, SHA-256 base64url, uniqueness)
- [x] Unit tests for \`getToken()\` resolution order (env > persisted, NO_OAUTH guard, caching)
- [x] Existing 18 tests still pass — no regressions
- [x] \`pnpm smoke\` still 4/4 OK
- [ ] **Manual end-to-end against staging once #327 deploys** — flow MCP → auth.ferrlabs.com → /authorize → callback → /exchange → token persisted → tool call succeeds

## Not in this PR (future)

- **Device Code Grant fallback** for headless environments (SSH, container) — separate issue when needed
- **Refresh tokens** — for now the persisted session token lives for its API-defined TTL (7 days), then re-runs OAuth on next call
- **Loopback port wildcard** server-side — currently pinned to 54321/54322; if those conflict for someone we'll add real wildcard support in #327 follow-up
- **Multi-account / account switching** — defer until a user actually asks