### PR TITLE
chore(ci): switch workflows from self-hosted ferrlabs-k8s to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test
     uses: FerrLabs/.github/.github/workflows/reusable-ci-node.yml@main
     with:
-      runner: ferrlabs-k8s
+      runner: ubuntu-latest
       install-args: ''
       enable-lint: false
       enable-knip: false
@@ -28,7 +28,7 @@ jobs:
   release:
     name: Release
     needs: test
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.test.result == 'success') || (github.event_name == 'workflow_dispatch' && needs.test.result == 'success')
     permissions:
       contents: write

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish-npm:
     name: Publish npm
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Prep for making the repo public: the MCP workflows reference `runs-on: ferrlabs-k8s` (self-hosted runners on the personal k8s cluster). That label is meaningless to the public — forks would fail with a "no runner matches the label" queue, and even within FerrLabs it leaks internal infra naming.

Switch all three jobs to the standard GitHub-hosted `ubuntu-latest`:

- `ci.yml` → `Test` job (via the `runner:` input on the reusable workflow) + `Release` job
- `pr-title.yml` → `Conventional commits` job
- `release.yml` → `Publish npm` job

Reusable workflows live in `FerrLabs/.github` which is already public, so the `uses: FerrLabs/.github/.github/workflows/*@main` references keep working from a public repo.

## Test plan

- [ ] CI passes on this PR running on `ubuntu-latest`
- [ ] After merge, the release flow runs on `ubuntu-latest` and still auto-publishes to npm