### PR TITLE
fix(auth): use rundll32 on Windows to avoid cmd & parsing breaking the OAuth URL

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -28,7 +28,7 @@ function openBrowser(url: string): void {
   const args: { cmd: string; args: string[] } = (() => {
     switch (platform()) {
       case 'win32':
-        return { cmd: 'cmd', args: ['/c', 'start', '""', url] };
+        return { cmd: 'rundll32', args: ['url.dll,FileProtocolHandler', url] };
       case 'darwin':
         return { cmd: 'open', args: [url] };
       default:


### PR DESCRIPTION
Fixes a Windows-only bug discovered when testing the live OAuth flow.

## Symptom

When the MCP triggers the loopback OAuth flow on Windows, the browser opens but lands on `https://auth.ferrlabs.com/authorize?client_id=mcp` — everything **after the first `&`** is missing. The auth SPA then shows:

> This link is missing required parameters (client_id, redirect_uri). It may have been truncated.

## Root cause

The previous launcher was:

```ts
spawn('cmd', ['/c', 'start', '""', url])
```

Node passes the args correctly, but cmd.exe re-parses the line and treats `&` as a **command separator**. So with a URL like `?client_id=mcp&redirect_uri=...&state=...`, cmd runs:

```
start "" https://auth.ferrlabs.com/authorize?client_id=mcp
` (then tries to run `redirect_uri=...` as a separate command, which fails silently)
```

The browser does open — but with the truncated URL.

## Fix

Switch to `rundll32 url.dll,FileProtocolHandler <url>` which is the Windows-native way to open a URL **without going through cmd**'s parser. The URL is passed verbatim as an argument to rundll32, no shell interpretation, no special-char issues.

This is the same approach the `open` npm package uses internally on Windows.

## Test plan

- [x] `pnpm test` — 34 tests pass, no regression
- [x] `pnpm build` — clean
- [ ] Manual Windows test: hit `list_orgs` from Claude → browser opens on the full URL with all params → consent → token persisted

macOS (`open`) and Linux (`xdg-open`) paths unchanged — those handle `&` natively.