### PR TITLE
feat(transport): dual-transport — stdio default + Streamable HTTP for hosted use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,37 @@ jobs:
       - run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-ghcr:
+    name: Publish GHCR image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute version
+        id: ver
+        run: |
+          v="${GITHUB_REF_NAME#v}"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/ferrlabs/mcp:${{ steps.ver.outputs.version }}
+            ghcr.io/ferrlabs/mcp:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/FerrLabs/MCP
+            org.opencontainers.image.version=${{ steps.ver.outputs.version }}
+            org.opencontainers.image.licenses=MPL-2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:24-alpine AS build
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY tsconfig.json ./
+COPY src ./src
+RUN pnpm build && pnpm prune --prod
+
+FROM node:24-alpine
+WORKDIR /app
+ENV NODE_ENV=production \
+    FERRLABS_MCP_MODE=http \
+    PORT=3000 \
+    HOST=0.0.0.0
+RUN addgroup -S app && adduser -S app -G app
+COPY --from=build --chown=app:app /app/node_modules ./node_modules
+COPY --from=build --chown=app:app /app/dist ./dist
+COPY --from=build --chown=app:app /app/package.json ./
+USER app
+EXPOSE 3000
+HEALTHCHECK --interval=15s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -qO- http://127.0.0.1:3000/health || exit 1
+CMD ["node", "dist/index.js"]

--- a/src/auth/__tests__/context.test.ts
+++ b/src/auth/__tests__/context.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('per-request bearer token takes precedence over env/persisted', () => {
+  beforeEach(() => {
+    delete process.env.FERRLABS_API_TOKEN;
+    delete process.env.FERRFLOW_API_TOKEN;
+    process.env.FERRLABS_MCP_NO_PERSIST = '1';
+    process.env.FERRLABS_MCP_NO_OAUTH = '1';
+  });
+
+  it('returns the bearer from AuthContext when set', async () => {
+    const { runWithAuthContext } = await import('../context.js');
+    const { getToken } = await import('../index.js');
+    const result = await runWithAuthContext({ bearerToken: 'fl_req_token' }, () => getToken());
+    expect(result).toBe('fl_req_token');
+  });
+
+  it('bearer from context wins over FERRLABS_API_TOKEN env', async () => {
+    process.env.FERRLABS_API_TOKEN = 'fl_env';
+    const { runWithAuthContext } = await import('../context.js');
+    const { getToken } = await import('../index.js');
+    const result = await runWithAuthContext({ bearerToken: 'fl_req' }, () => getToken());
+    expect(result).toBe('fl_req');
+  });
+
+  it('falls back to env when context has no bearer', async () => {
+    process.env.FERRLABS_API_TOKEN = 'fl_env_only';
+    const { runWithAuthContext } = await import('../context.js');
+    const { getToken } = await import('../index.js');
+    const result = await runWithAuthContext({}, () => getToken());
+    expect(result).toBe('fl_env_only');
+  });
+});

--- a/src/auth/context.ts
+++ b/src/auth/context.ts
@@ -1,0 +1,15 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface AuthContext {
+  bearerToken?: string;
+}
+
+export const authContext = new AsyncLocalStorage<AuthContext>();
+
+export function runWithAuthContext<T>(ctx: AuthContext, fn: () => Promise<T>): Promise<T> {
+  return authContext.run(ctx, fn);
+}
+
+export function getRequestBearerToken(): string | undefined {
+  return authContext.getStore()?.bearerToken;
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,10 +1,18 @@
 import { readPersistedToken, writePersistedToken } from './persistence.js';
 import { runLoopbackOauthFlow } from './oauth.js';
+import { getRequestBearerToken } from './context.js';
 
 let cached: string | null = null;
 let inFlight: Promise<string> | null = null;
 
 export async function getToken(): Promise<string> {
+  const perRequest = getRequestBearerToken();
+  if (perRequest) return perRequest;
+
+  if (process.env.FERRLABS_MCP_MODE === 'http') {
+    throw new Error('Bearer token required. Send `Authorization: Bearer fl_...` on each request.');
+  }
+
   if (cached) return cached;
 
   const envToken = process.env.FERRLABS_API_TOKEN ?? process.env.FERRFLOW_API_TOKEN;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,25 @@
 #!/usr/bin/env node
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { registerStatsTools } from './tools/stats.js';
-import { registerTokenTools } from './tools/tokens.js';
-import { registerOrgsTools } from './tools/orgs.js';
-import { registerVaultsTools } from './tools/vaults.js';
-import { registerIssuesTools } from './tools/issues.js';
-import { registerSubscriptionsTools } from './tools/subscriptions.js';
-import { registerDocsTools } from './tools/docs.js';
+import { startStdioServer } from './transports/stdio.js';
+import { startHttpServer } from './transports/http.js';
 
-const server = new McpServer({
-  name: 'ferrlabs',
-  version: '4.0.0',
+async function main(): Promise<void> {
+  const mode =
+    process.env.FERRLABS_MCP_MODE ?? (process.argv.includes('--http') ? 'http' : 'stdio');
+
+  if (mode === 'http') {
+    const port = Number(process.env.PORT ?? '3000');
+    await startHttpServer({
+      port,
+      host: process.env.HOST,
+      stateless: process.env.FERRLABS_MCP_STATEFUL !== '1',
+    });
+    return;
+  }
+
+  await startStdioServer();
+}
+
+main().catch((err: unknown) => {
+  console.error('ferrlabs-mcp fatal:', err instanceof Error ? err.message : err);
+  process.exit(1);
 });
-
-registerStatsTools(server);
-registerTokenTools(server);
-registerOrgsTools(server);
-registerVaultsTools(server);
-registerIssuesTools(server);
-registerSubscriptionsTools(server);
-registerDocsTools(server);
-
-const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
-const transport = new StdioServerTransport();
-await server.connect(transport);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,22 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerStatsTools } from './tools/stats.js';
+import { registerTokenTools } from './tools/tokens.js';
+import { registerOrgsTools } from './tools/orgs.js';
+import { registerVaultsTools } from './tools/vaults.js';
+import { registerIssuesTools } from './tools/issues.js';
+import { registerSubscriptionsTools } from './tools/subscriptions.js';
+import { registerDocsTools } from './tools/docs.js';
+
+const VERSION = '5.1.1';
+
+export function createMcpServer(): McpServer {
+  const server = new McpServer({ name: 'ferrlabs', version: VERSION });
+  registerStatsTools(server);
+  registerTokenTools(server);
+  registerOrgsTools(server);
+  registerVaultsTools(server);
+  registerIssuesTools(server);
+  registerSubscriptionsTools(server);
+  registerDocsTools(server);
+  return server;
+}

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,0 +1,96 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createMcpServer } from '../server.js';
+import { runWithAuthContext } from '../auth/context.js';
+
+function extractBearer(req: IncomingMessage): string | undefined {
+  const header = req.headers['authorization'];
+  if (typeof header !== 'string') return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match?.[1];
+}
+
+export interface HttpServerOptions {
+  port: number;
+  host?: string;
+  stateless?: boolean;
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown | undefined> {
+  if (req.method !== 'POST') return undefined;
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) return resolve(undefined);
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
+  const { port, host = '0.0.0.0', stateless = true } = opts;
+  const transports = new Map<string, StreamableHTTPServerTransport>();
+
+  async function handleMcpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const sessionId = (req.headers['mcp-session-id'] as string | undefined) ?? undefined;
+    let transport = sessionId ? transports.get(sessionId) : undefined;
+
+    if (!transport) {
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: stateless ? undefined : randomUUID,
+        onsessioninitialized: stateless
+          ? undefined
+          : (newSessionId: string) => {
+              if (transport) transports.set(newSessionId, transport);
+            },
+      });
+      transport.onclose = () => {
+        if (sessionId) transports.delete(sessionId);
+      };
+      const server = createMcpServer();
+      await server.connect(transport);
+    }
+
+    const body = await readJsonBody(req);
+    const bearerToken = extractBearer(req);
+    await runWithAuthContext({ bearerToken }, () => transport.handleRequest(req, res, body));
+  }
+
+  const httpServer = createServer((req, res) => {
+    const url = req.url ?? '/';
+    if (url === '/health' || url === '/livez' || url === '/readyz') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', service: 'ferrlabs-mcp' }));
+      return;
+    }
+    if (url === '/mcp' || url.startsWith('/mcp?')) {
+      handleMcpRequest(req, res).catch((err) => {
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+        } else {
+          res.end();
+        }
+      });
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(port, host, () => {
+      console.error(`ferrlabs-mcp HTTP transport listening on http://${host}:${port}/mcp`);
+      resolve();
+    });
+  });
+}

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -1,0 +1,8 @@
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createMcpServer } from '../server.js';
+
+export async function startStdioServer(): Promise<void> {
+  const server = createMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}


### PR DESCRIPTION
Adds an HTTP transport so the same MCP can be installed locally via `npx -y @ferrlabs/mcp` OR hosted at `mcp.ferrlabs.com` for zero-install web clients.

## Architecture

```
src/
├── index.ts              # CLI entrypoint, picks transport from env/flag
├── server.ts             # createMcpServer() — registers tools, transport-agnostic
├── transports/
│   ├── stdio.ts          # StdioServerTransport (default)
│   └── http.ts           # StreamableHTTPServerTransport on Node http.createServer
└── auth/
    ├── context.ts        # AsyncLocalStorage for per-request bearer token
    ├── index.ts          # getToken() — context > env > persisted > OAuth
    └── …
```

## Mode selection

| Trigger | Transport |
|---|---|
| default (no env/flag) | stdio |
| `FERRLABS_MCP_MODE=http` or `--http` flag | HTTP |

HTTP mode listens on `PORT` (default 3000), serves `POST /mcp` for JSON-RPC + SSE streaming, and `GET /health` for K8s probes.

## Auth difference

**stdio** (unchanged): `getToken()` lazy-runs OAuth loopback, persists to disk. Each MCP process serves one user.

**HTTP**: each request must carry `Authorization: Bearer fl_…`. The HTTP transport extracts it, wraps the request handling in an `AsyncLocalStorage` context, and `getToken()` pulls from context first. If no bearer comes in and we're in HTTP mode, we throw immediately (no fallback to env/persisted/OAuth — multi-tenant safety).

Public tools (`get_stats`, `health_check`, `fetch_docs`) don't call `getToken()` and work anonymously.

## Tested

- `pnpm test` — 37 passing (3 new for AsyncLocalStorage context)
- `pnpm smoke` (stdio) — 4/4 OK
- Manual HTTP: `FERRLABS_MCP_MODE=http PORT=3001 node dist/index.js` + curl on `/mcp` POST with initialize → `serverInfo: ferrlabs@5.1.1` ✓
- `/health` returns 200 OK

## Follow-up

- Infra repo PR to deploy on `mcp.ferrlabs.com` (Dockerfile, K8s manifest, Traefik ingress) — tracked separately
- Future: WWW-Authenticate header on 401 so MCP clients can drive OAuth themselves per spec
- Future: stateful mode tuning if multi-message sessions become heavy
EOF
)