### PR TITLE
fix(docker): disable husky postinstall in Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM node:24-alpine AS build
 WORKDIR /app
+ENV HUSKY=0 \
+    CI=true
 RUN corepack enable
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY tsconfig.json ./
 COPY src ./src
-RUN pnpm build && pnpm prune --prod
+RUN pnpm build && pnpm prune --prod --ignore-scripts
 
 FROM node:24-alpine
 WORKDIR /app


### PR DESCRIPTION
Fixes [release.yml run failure](https://github.com/FerrLabs/MCP/actions) on v5.2.0 — the GHCR image build failed because `pnpm install` triggers husky's `prepare` hook, which tries to access `.git/` (not in Docker build context):

```
$ husky
.git can't be found
[ERR_PNPM_IGNORED_BUILDS]
```

## Fix

- `ENV HUSKY=0` — documented escape hatch in husky docs to skip the prepare hook entirely
- `--ignore-scripts` on `pnpm install` — belt-and-suspenders, skips all lifecycle scripts (husky, esbuild postinstall warning, etc.)
- `pnpm build` still runs explicitly so dist/ ends up populated

No effect on local dev (`pnpm install` outside CI still runs husky and sets up git hooks normally).