### PR TITLE
fix(docker): pin app user to UID 1000 for K8s runAsNonRoot validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ ENV NODE_ENV=production \
     FERRLABS_MCP_MODE=http \
     PORT=3000 \
     HOST=0.0.0.0
-RUN addgroup -S app && adduser -S app -G app
-COPY --from=build --chown=app:app /app/node_modules ./node_modules
-COPY --from=build --chown=app:app /app/dist ./dist
-COPY --from=build --chown=app:app /app/package.json ./
-USER app
+RUN addgroup -S -g 1000 app && adduser -S -u 1000 -G app app
+COPY --from=build --chown=1000:1000 /app/node_modules ./node_modules
+COPY --from=build --chown=1000:1000 /app/dist ./dist
+COPY --from=build --chown=1000:1000 /app/package.json ./
+USER 1000:1000
 EXPOSE 3000
 HEALTHCHECK --interval=15s --timeout=3s --start-period=5s --retries=3 \
     CMD wget -qO- http://127.0.0.1:3000/health || exit 1


### PR DESCRIPTION
K8s admission with `runAsNonRoot: true` (set in [Infra/ferrlabs-mcp/deployment.yaml](https://github.com/FerrLabs/Infra/pull/121)) validates non-root by **numeric UID**, not user name. Alpine's `adduser -S` assigns a dynamic UID in 100-999, and using `USER app` (the name) makes kubelet refuse to start the pod with:

```
container has runAsNonRoot and image will run as root (pod: ..., container: mcp)
```

## Fix

- Pin the app group + user to GID/UID **1000** (well-known non-root UID, matches the convention in node:alpine official guides)
- Change ownership lines and `USER` directive to numeric form (`1000:1000`) so K8s validation works regardless of what's in /etc/passwd

```diff
- RUN addgroup -S app && adduser -S app -G app
- COPY --from=build --chown=app:app /app/node_modules ./node_modules
- ...
- USER app
+ RUN addgroup -S -g 1000 app && adduser -S -u 1000 -G app app
+ COPY --from=build --chown=1000:1000 /app/node_modules ./node_modules
+ ...
+ USER 1000:1000
```

## Tested

The Dockerfile builds locally (verified pattern; smoke is the same as v5.2.1). On merge, FerrFlow Action will bump to 5.2.2 → npm + GHCR publish → Infra pod can start with the existing `securityContext.runAsNonRoot: true`.