### PR TITLE
fix(docker): reuse node:alpine's built-in UID 1000 user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ ENV NODE_ENV=production \
     FERRLABS_MCP_MODE=http \
     PORT=3000 \
     HOST=0.0.0.0
-RUN addgroup -S -g 1000 app && adduser -S -u 1000 -G app app
 COPY --from=build --chown=1000:1000 /app/node_modules ./node_modules
 COPY --from=build --chown=1000:1000 /app/dist ./dist
 COPY --from=build --chown=1000:1000 /app/package.json ./


### PR DESCRIPTION
v5.2.2 GHCR build failed:

```
ERROR: process "addgroup -S -g 1000 app && adduser -S -u 1000 -G app app" exit code: 1
```

`node:24-alpine` already ships with a `node` user at UID/GID **1000**, so `addgroup -g 1000` collides with the existing GID. Drop the redundant user creation and just `USER 1000:1000` directly (numeric form, no need to resolve /etc/passwd, K8s `runAsNonRoot` happy).

npm v5.2.2 published fine — only GHCR was blocked. This patch will produce a v5.2.3 with both publishing.