### PR TITLE
fix(api-client): forward token via Authorization Bearer too + better error surfacing

### DIFF
--- a/src/tools/__tests__/api-client.test.ts
+++ b/src/tools/__tests__/api-client.test.ts
@@ -5,9 +5,11 @@ const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
 function makeResponse(body: unknown, status = 200): Response {
+  const text = body === undefined ? '' : JSON.stringify(body);
   return {
     ok: status >= 200 && status < 300,
     status,
+    text: () => Promise.resolve(text),
     json: () => Promise.resolve(body),
   } as unknown as Response;
 }
@@ -47,7 +49,7 @@ describe('apiRequest', () => {
 
   it('throws a generic error when response has no error field', async () => {
     mockFetch.mockResolvedValue(makeResponse({}, 500));
-    await expect(apiRequest('/broken')).rejects.toThrow('API error: 500');
+    await expect(apiRequest('/broken')).rejects.toThrow('API error: HTTP 500');
   });
 
   it('sends a JSON body for POST requests', async () => {

--- a/src/tools/__tests__/orgs.test.ts
+++ b/src/tools/__tests__/orgs.test.ts
@@ -14,9 +14,11 @@ const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
 function makeResponse(body: unknown, status = 200): Response {
+  const text = body === undefined ? '' : JSON.stringify(body);
   return {
     ok: status >= 200 && status < 300,
     status,
+    text: () => Promise.resolve(text),
     json: () => Promise.resolve(body),
   } as unknown as Response;
 }

--- a/src/tools/api-client.ts
+++ b/src/tools/api-client.ts
@@ -16,6 +16,7 @@ export async function apiRequest<T>(path: string, options: RequestOptions = {}):
 
   if (token) {
     headers['x-api-token'] = token;
+    headers['Authorization'] = `Bearer ${token}`;
   }
 
   const res = await fetch(`${API_URL}${path}`, {
@@ -28,10 +29,22 @@ export async function apiRequest<T>(path: string, options: RequestOptions = {}):
     return undefined as T;
   }
 
-  const data = await res.json();
+  const raw = await res.text();
+  let data: unknown = undefined;
+  if (raw) {
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      throw new Error(`API non-JSON response (HTTP ${res.status}): ${raw.slice(0, 200)}`);
+    }
+  }
 
   if (!res.ok) {
-    throw new Error(data.error ?? `API error: ${res.status}`);
+    const errMsg =
+      (data as { error?: string; message?: string } | undefined)?.error ??
+      (data as { error?: string; message?: string } | undefined)?.message ??
+      `API error: HTTP ${res.status}`;
+    throw new Error(errMsg);
   }
 
   return data as T;


### PR DESCRIPTION
Two bugs surfaced in production after the HTTP MCP migration:

## 1. Token sent only as `x-api-token`

The HTTP MCP receives `Authorization: Bearer <token>` from clients. `getToken()` pulls that out via AsyncLocalStorage. But `apiRequest` only forwards it as `x-api-token` to `api.ferrlabs.com`.

The FerrLabs API accepts two token formats:
- `x-api-token: fl_...` — long-lived API tokens (created in app.ferrlabs.com UI)
- `Authorization: Bearer fft_...` — short-lived session tokens (from /v1/auth/exchange)

A session token (`fft_...` prefix) sent as `x-api-token` is rejected (empty body / 401) → `res.json()` throws "Unexpected end of JSON input" → tool returns isError.

Fix: send both headers. API accepts whichever matches its expected format.

## 2. Cryptic 'Unexpected end of JSON input' on non-JSON responses

`res.json()` throws an unhelpful error when the body is empty or not JSON (which is exactly what happens when auth fails silently). Read as text first, then JSON-parse with a meaningful error message.

```diff
- const data = await res.json();
+ const raw = await res.text();
+ let data: unknown = undefined;
+ if (raw) {
+   try { data = JSON.parse(raw); }
+   catch { throw new Error(`API non-JSON response (HTTP ${res.status}): ${raw.slice(0, 200)}`); }
+ }
```

Also extracts error message from `{ error }` OR `{ message }` envelope (the API uses both depending on endpoint).

## Tested

- 40/40 tests pass (2 tests updated for new error message format + .text() mock)
- After merge → v5.2.x release → npm + GHCR → Infra picks up automatically