### PR TITLE
fix(http): return 404 on unknown session-id so clients reinit transparently

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -43,17 +43,34 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
     const sessionId = (req.headers['mcp-session-id'] as string | undefined) ?? undefined;
     let transport = sessionId ? transports.get(sessionId) : undefined;
 
+    if (sessionId && !transport && !stateless) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: -32001,
+            message: `Session ${sessionId} not found — reinitialize to obtain a new session`,
+          },
+          id: null,
+        }),
+      );
+      return;
+    }
+
     if (!transport) {
+      let createdSessionId: string | undefined;
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: stateless ? undefined : randomUUID,
         onsessioninitialized: stateless
           ? undefined
           : (newSessionId: string) => {
+              createdSessionId = newSessionId;
               if (transport) transports.set(newSessionId, transport);
             },
       });
       transport.onclose = () => {
-        if (sessionId) transports.delete(sessionId);
+        if (createdSessionId) transports.delete(createdSessionId);
       };
       const server = createMcpServer();
       await server.connect(transport);


### PR DESCRIPTION
Symptom (just observed in prod after FluxCD rolled the pod from v5.2.3 to v5.2.4):

```
Bad Request: Server not initialized
```

The client (Claude Code) was still sending the previous pod's `mcp-session-id`. The new pod's in-memory session Map was empty, so my code silently created a fresh transport for that unknown ID — but the new transport had never been initialized, so the next `tools/call` failed with that confusing error.

## Fix

When `mcp-session-id` is present and we don't have that session in our Map, return a clean **404** with a JSON-RPC error envelope:

```json
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32001,
    "message": "Session <id> not found — reinitialize to obtain a new session"
  },
  "id": null
}
```

The MCP spec says the client should react to 404 by dropping its session and reinitializing — so the next request creates a fresh session transparently. No "restart your client" needed after a pod roll.

Also caught a related bug: the previous `onclose` handler captured the **inbound** `sessionId` (which is undefined for new sessions). Fixed to capture the **created** session id via the `onsessioninitialized` callback closure, so cleanup actually frees the right slot in the Map.