### PR TITLE
feat: add FerrTrack, FerrGrowth, FerrFleet sub-MCPs

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -13,7 +13,10 @@
         { "path": "package.json", "format": "json" },
         { "path": "packages/mcp-core/package.json", "format": "json" },
         { "path": "packages/mcp/package.json", "format": "json" },
-        { "path": "packages/mcp-vault/package.json", "format": "json" }
+        { "path": "packages/mcp-vault/package.json", "format": "json" },
+        { "path": "packages/mcp-track/package.json", "format": "json" },
+        { "path": "packages/mcp-growth/package.json", "format": "json" },
+        { "path": "packages/mcp-fleet/package.json", "format": "json" }
       ]
     }
   ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,18 @@ jobs:
         run: pnpm --filter @ferrlabs/mcp-vault publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish @ferrlabs/mcp-track
+        run: pnpm --filter @ferrlabs/mcp-track publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish @ferrlabs/mcp-growth
+        run: pnpm --filter @ferrlabs/mcp-growth publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish @ferrlabs/mcp-fleet
+        run: pnpm --filter @ferrlabs/mcp-fleet publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-ghcr:
     name: Publish GHCR image (${{ matrix.package }})
@@ -41,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [mcp, mcp-vault]
+        package: [mcp, mcp-vault, mcp-track, mcp-growth, mcp-fleet]
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,17 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY packages/mcp-core/package.json packages/mcp-core/
 COPY packages/mcp/package.json packages/mcp/
 COPY packages/mcp-vault/package.json packages/mcp-vault/
+COPY packages/mcp-track/package.json packages/mcp-track/
+COPY packages/mcp-growth/package.json packages/mcp-growth/
+COPY packages/mcp-fleet/package.json packages/mcp-fleet/
 RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY packages/mcp-core packages/mcp-core
 COPY packages/mcp packages/mcp
 COPY packages/mcp-vault packages/mcp-vault
-RUN pnpm -r --filter './packages/*' run build
+COPY packages/mcp-track packages/mcp-track
+COPY packages/mcp-growth packages/mcp-growth
+COPY packages/mcp-fleet packages/mcp-fleet
+RUN pnpm run build
 RUN pnpm --filter "@ferrlabs/${PACKAGE}" deploy --prod --legacy /out
 
 FROM node:24-alpine

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "*.{ts,tsx,js,jsx,mjs,cjs,json,md,css}": "prettier --write"
   },
   "scripts": {
-    "build": "pnpm --filter @ferrlabs/mcp-core run build && pnpm --filter @ferrlabs/mcp run build && pnpm --filter @ferrlabs/mcp-vault run build",
+    "build": "pnpm --filter @ferrlabs/mcp-core run build && pnpm --filter @ferrlabs/mcp run build && pnpm --filter @ferrlabs/mcp-vault run build && pnpm --filter @ferrlabs/mcp-track run build && pnpm --filter @ferrlabs/mcp-growth run build && pnpm --filter @ferrlabs/mcp-fleet run build",
     "ci:local": "pnpm build && pnpm typecheck && pnpm test",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "pnpm --filter @ferrlabs/mcp-core run build && pnpm --filter @ferrlabs/mcp run typecheck && pnpm --filter @ferrlabs/mcp-vault run typecheck"
+    "typecheck": "pnpm --filter @ferrlabs/mcp-core run build && pnpm --filter @ferrlabs/mcp run typecheck && pnpm --filter @ferrlabs/mcp-vault run typecheck && pnpm --filter @ferrlabs/mcp-track run typecheck && pnpm --filter @ferrlabs/mcp-growth run typecheck && pnpm --filter @ferrlabs/mcp-fleet run typecheck"
   }
 }

--- a/packages/mcp-core/src/api-client.ts
+++ b/packages/mcp-core/src/api-client.ts
@@ -1,13 +1,20 @@
-const API_URL = process.env.API_URL ?? 'https://api.ferrlabs.com';
+const DEFAULT_API_URL = process.env.API_URL ?? 'https://api.ferrlabs.com';
 
 interface RequestOptions {
   method?: string;
   body?: unknown;
   token?: string;
+  /**
+   * Override the API base URL for this call. Sub-MCPs targeting per-product
+   * APIs (e.g. `api.ferrgrowth.com`, `api.ferrfleet.com`) set this on each
+   * tool call. Falls back to `API_URL` env var, then `api.ferrlabs.com`.
+   */
+  baseUrl?: string;
 }
 
 export async function apiRequest<T>(path: string, options: RequestOptions = {}): Promise<T> {
-  const { method = 'GET', body, token } = options;
+  const { method = 'GET', body, token, baseUrl } = options;
+  const base = baseUrl ?? DEFAULT_API_URL;
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -19,7 +26,7 @@ export async function apiRequest<T>(path: string, options: RequestOptions = {}):
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  const res = await fetch(`${API_URL}${path}`, {
+  const res = await fetch(`${base}${path}`, {
     method,
     headers,
     body: body ? JSON.stringify(body) : undefined,

--- a/packages/mcp-fleet/package.json
+++ b/packages/mcp-fleet/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@ferrlabs/mcp-fleet",
+  "version": "6.0.0",
+  "description": "Model Context Protocol server for FerrFleet — agents, runs, skills",
+  "license": "MPL-2.0",
+  "type": "module",
+  "bin": {
+    "ferrlabs-mcp-fleet": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "keywords": [
+    "mcp",
+    "ferrlabs",
+    "ferrfleet",
+    "agents",
+    "model-context-protocol"
+  ],
+  "dependencies": {
+    "@ferrlabs/mcp-core": "workspace:^",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^4.3.6"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FerrLabs/MCP.git",
+    "directory": "packages/mcp-fleet"
+  }
+}

--- a/packages/mcp-fleet/src/api-base.ts
+++ b/packages/mcp-fleet/src/api-base.ts
@@ -1,0 +1,1 @@
+export const FLEET_API_URL = process.env.FERRFLEET_API_URL ?? 'https://api.ferrfleet.com';

--- a/packages/mcp-fleet/src/index.ts
+++ b/packages/mcp-fleet/src/index.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { runMcp } from '@ferrlabs/mcp-core';
+import { registerAgentTools } from './tools/agents.js';
+import { registerRunTools } from './tools/runs.js';
+
+runMcp({
+  name: 'ferrlabs-fleet',
+  version: '6.0.0',
+  register: (server) => {
+    registerAgentTools(server);
+    registerRunTools(server);
+  },
+}).catch((err: unknown) => {
+  console.error('ferrlabs-mcp-fleet fatal:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/mcp-fleet/src/tools/agents.ts
+++ b/packages/mcp-fleet/src/tools/agents.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { FLEET_API_URL } from '../api-base.js';
+
+interface Agent {
+  id: string;
+  name: string;
+  description: string | null;
+  visibility: string;
+  first_party_for_product: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export function registerAgentTools(server: McpServer) {
+  server.tool(
+    'list_agents',
+    'List FerrFleet agents available to the authenticated user (marketplace + custom).',
+    {},
+    async () => {
+      const token = await getToken();
+      const agents = await apiRequest<Agent[]>('/v1/agents', { token, baseUrl: FLEET_API_URL });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(agents, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'get_agent',
+    'Get full details of a FerrFleet agent (manifest, scopes, last run).',
+    {
+      agent_id: z.string().min(1).describe('Agent id'),
+    },
+    async ({ agent_id }) => {
+      const token = await getToken();
+      const agent = await apiRequest<Agent>(`/v1/agents/${encodeURIComponent(agent_id)}`, {
+        token,
+        baseUrl: FLEET_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(agent, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-fleet/src/tools/runs.ts
+++ b/packages/mcp-fleet/src/tools/runs.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { FLEET_API_URL } from '../api-base.js';
+
+interface Run {
+  id: string;
+  agent_id: string;
+  status: string;
+  started_at: string | null;
+  finished_at: string | null;
+  triggered_by: string;
+  created_at: string;
+}
+
+export function registerRunTools(server: McpServer) {
+  server.tool(
+    'list_runs',
+    'List recent FerrFleet runs for the authenticated org (most recent first).',
+    {
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('Max runs to return (default 25)'),
+    },
+    async ({ limit }) => {
+      const token = await getToken();
+      const qs = limit !== undefined ? `?limit=${limit}` : '';
+      const runs = await apiRequest<Run[]>(`/v1/runs${qs}`, {
+        token,
+        baseUrl: FLEET_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(runs, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'get_run',
+    'Get details + transcript of a single FerrFleet run.',
+    {
+      run_id: z.string().min(1).describe('Run id'),
+    },
+    async ({ run_id }) => {
+      const token = await getToken();
+      const run = await apiRequest<Run>(`/v1/runs/${encodeURIComponent(run_id)}`, {
+        token,
+        baseUrl: FLEET_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(run, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-fleet/tsconfig.json
+++ b/packages/mcp-fleet/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp-growth/package.json
+++ b/packages/mcp-growth/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@ferrlabs/mcp-growth",
+  "version": "6.0.0",
+  "description": "Model Context Protocol server for FerrGrowth — sites, pages, forms, audits",
+  "license": "MPL-2.0",
+  "type": "module",
+  "bin": {
+    "ferrlabs-mcp-growth": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "keywords": [
+    "mcp",
+    "ferrlabs",
+    "ferrgrowth",
+    "model-context-protocol"
+  ],
+  "dependencies": {
+    "@ferrlabs/mcp-core": "workspace:^",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^4.3.6"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FerrLabs/MCP.git",
+    "directory": "packages/mcp-growth"
+  }
+}

--- a/packages/mcp-growth/src/api-base.ts
+++ b/packages/mcp-growth/src/api-base.ts
@@ -1,0 +1,1 @@
+export const GROWTH_API_URL = process.env.FERRGROWTH_API_URL ?? 'https://api.ferrgrowth.com';

--- a/packages/mcp-growth/src/index.ts
+++ b/packages/mcp-growth/src/index.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { runMcp } from '@ferrlabs/mcp-core';
+import { registerSiteTools } from './tools/sites.js';
+import { registerPageTools } from './tools/pages.js';
+
+runMcp({
+  name: 'ferrlabs-growth',
+  version: '6.0.0',
+  register: (server) => {
+    registerSiteTools(server);
+    registerPageTools(server);
+  },
+}).catch((err: unknown) => {
+  console.error('ferrlabs-mcp-growth fatal:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/mcp-growth/src/tools/pages.ts
+++ b/packages/mcp-growth/src/tools/pages.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { GROWTH_API_URL } from '../api-base.js';
+
+interface Page {
+  id: string;
+  site_id: string;
+  slug: string;
+  title: string;
+  published: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export function registerPageTools(server: McpServer) {
+  server.tool(
+    'list_pages',
+    'List pages on a FerrGrowth site.',
+    {
+      site_id: z.string().min(1).describe('Site id'),
+    },
+    async ({ site_id }) => {
+      const token = await getToken();
+      const pages = await apiRequest<Page[]>(`/v1/sites/${encodeURIComponent(site_id)}/pages`, {
+        token,
+        baseUrl: GROWTH_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(pages, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-growth/src/tools/sites.ts
+++ b/packages/mcp-growth/src/tools/sites.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { GROWTH_API_URL } from '../api-base.js';
+
+interface Site {
+  id: string;
+  slug: string;
+  name: string;
+  domain: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export function registerSiteTools(server: McpServer) {
+  server.tool(
+    'list_sites',
+    "List FerrGrowth sites in the authenticated user's org.",
+    {},
+    async () => {
+      const token = await getToken();
+      const sites = await apiRequest<Site[]>('/v1/sites', { token, baseUrl: GROWTH_API_URL });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(sites, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'get_site',
+    'Get details for a single FerrGrowth site (status, custom domain, etc.).',
+    {
+      site_id: z.string().min(1).describe('Site id'),
+    },
+    async ({ site_id }) => {
+      const token = await getToken();
+      const site = await apiRequest<Site>(`/v1/sites/${encodeURIComponent(site_id)}`, {
+        token,
+        baseUrl: GROWTH_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(site, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-growth/tsconfig.json
+++ b/packages/mcp-growth/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp-track/package.json
+++ b/packages/mcp-track/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@ferrlabs/mcp-track",
+  "version": "6.0.0",
+  "description": "Model Context Protocol server for FerrTrack — issues, labels, comments",
+  "license": "MPL-2.0",
+  "type": "module",
+  "bin": {
+    "ferrlabs-mcp-track": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "keywords": [
+    "mcp",
+    "ferrlabs",
+    "ferrtrack",
+    "issues",
+    "model-context-protocol"
+  ],
+  "dependencies": {
+    "@ferrlabs/mcp-core": "workspace:^",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^4.3.6"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FerrLabs/MCP.git",
+    "directory": "packages/mcp-track"
+  }
+}

--- a/packages/mcp-track/src/index.ts
+++ b/packages/mcp-track/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { runMcp } from '@ferrlabs/mcp-core';
+import { registerIssueDetailsTool } from './tools/issue-details.js';
+import { registerLabelTools } from './tools/labels.js';
+import { registerCommentTools } from './tools/comments.js';
+
+runMcp({
+  name: 'ferrlabs-track',
+  version: '6.0.0',
+  register: (server) => {
+    registerIssueDetailsTool(server);
+    registerLabelTools(server);
+    registerCommentTools(server);
+  },
+}).catch((err: unknown) => {
+  console.error('ferrlabs-mcp-track fatal:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/mcp-track/src/tools/comments.ts
+++ b/packages/mcp-track/src/tools/comments.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+
+interface Comment {
+  id: string;
+  issue_number: number;
+  author_id: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export function registerCommentTools(server: McpServer) {
+  server.tool(
+    'list_issue_comments',
+    'List all comments on a FerrTrack issue.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      number: z.number().int().min(1).describe('Issue number'),
+    },
+    async ({ org_slug, project_slug, number }) => {
+      const token = await getToken();
+      const comments = await apiRequest<Comment[]>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/issues/${number}/comments`,
+        { token },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(comments, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-track/src/tools/issue-details.ts
+++ b/packages/mcp-track/src/tools/issue-details.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+
+interface IssueDetails {
+  id: string;
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  author_id: string;
+  assignee_id: string | null;
+  labels: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export function registerIssueDetailsTool(server: McpServer) {
+  server.tool(
+    'get_issue',
+    'Get the full content of a FerrTrack issue (title, body, state, labels, assignee).',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      number: z.number().int().min(1).describe('Issue number'),
+    },
+    async ({ org_slug, project_slug, number }) => {
+      const token = await getToken();
+      const issue = await apiRequest<IssueDetails>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/issues/${number}`,
+        { token },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(issue, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-track/src/tools/labels.ts
+++ b/packages/mcp-track/src/tools/labels.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+
+interface Label {
+  id: string;
+  name: string;
+  color: string;
+  description: string | null;
+  created_at: string;
+}
+
+export function registerLabelTools(server: McpServer) {
+  server.tool(
+    'list_labels',
+    'List all FerrTrack labels for a project.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+    },
+    async ({ org_slug, project_slug }) => {
+      const token = await getToken();
+      const labels = await apiRequest<Label[]>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/labels`,
+        { token },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(labels, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-track/tsconfig.json
+++ b/packages/mcp-track/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,42 @@ importers:
         specifier: ^1.0.0
         version: 1.29.0(zod@4.3.6)
 
+  packages/mcp-fleet:
+    dependencies:
+      '@ferrlabs/mcp-core':
+        specifier: workspace:^
+        version: link:../mcp-core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.29.0(zod@4.3.6)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
+  packages/mcp-growth:
+    dependencies:
+      '@ferrlabs/mcp-core':
+        specifier: workspace:^
+        version: link:../mcp-core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.29.0(zod@4.3.6)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
+  packages/mcp-track:
+    dependencies:
+      '@ferrlabs/mcp-core':
+        specifier: workspace:^
+        version: link:../mcp-core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.29.0(zod@4.3.6)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
   packages/mcp-vault:
     dependencies:
       '@ferrlabs/mcp-core':


### PR DESCRIPTION
Three new sub-MCPs following the pattern from #126. Each is a separate npm package + GHCR image.

## Packages added

| Package | Tools | API target |
|---|---|---|
| `@ferrlabs/mcp-track` | `get_issue`, `list_labels`, `list_issue_comments` | api.ferrlabs.com (central) |
| `@ferrlabs/mcp-growth` | `list_sites`, `get_site`, `list_pages` | api.ferrgrowth.com (per-product) |
| `@ferrlabs/mcp-fleet` | `list_agents`, `get_agent`, `list_runs`, `get_run` | api.ferrfleet.com (per-product) |

Each is **opt-in** for users — install only the sub-MCPs you need to keep tool count per session low.

## New: per-product API base

`apiRequest` in `@ferrlabs/mcp-core` now accepts an optional `baseUrl` to target per-product APIs:

```ts
await apiRequest('/v1/sites', { token, baseUrl: 'https://api.ferrgrowth.com' });
```

mcp-growth and mcp-fleet target separate APIs (`api.ferrgrowth.com`, `api.ferrfleet.com`); mcp-track stays on `api.ferrlabs.com` because FerrTrack endpoints live on the central FerrLabs API (per `FerrLabs-Cloud/api/src/routes/issues.rs`).

Override per-product via env: `FERRGROWTH_API_URL`, `FERRFLEET_API_URL`.

## Build / publish

- 6 packages all build clean: `pnpm build` ✓
- 20 tests pass
- Release workflow publishes all 6 to npm + builds 5 GHCR images (mcp + 4 sub-MCPs)

## After merge

v7.0.0 (or v6.1.0 depending on FerrFlow's commit-type interpretation) ships:
- npm: `@ferrlabs/{mcp-core, mcp, mcp-vault, mcp-track, mcp-growth, mcp-fleet}`
- GHCR: `ghcr.io/ferrlabs/{mcp, mcp-vault, mcp-track, mcp-growth, mcp-fleet}`

Infra deployment per sub-MCP (`track.mcp.ferrlabs.com`, `growth.mcp.ferrlabs.com`, `fleet.mcp.ferrlabs.com`) is a follow-up Infra PR when you want to expose them hosted.