### PR TITLE
feat(http): OAuth protected-resource discovery — drive client OAuth via 401

### DIFF
--- a/packages/mcp-core/src/transports/http.ts
+++ b/packages/mcp-core/src/transports/http.ts
@@ -15,11 +15,25 @@ function extractBearer(req: IncomingMessage): string | undefined {
   return match?.[1];
 }
 
+function publicOrigin(req: IncomingMessage): string {
+  const proto =
+    (req.headers['x-forwarded-proto'] as string | undefined)?.split(',')[0]?.trim() ?? 'https';
+  const host = (req.headers['x-forwarded-host'] as string | undefined) ?? req.headers.host ?? '';
+  return `${proto}://${host}`;
+}
+
 export interface HttpServerOptions {
   port: number;
   host?: string;
   stateless?: boolean;
   createServer: () => McpServer;
+  /**
+   * URL of the OAuth 2.0 Authorization Server users authenticate against.
+   * Surfaced to MCP clients via /.well-known/oauth-protected-resource so
+   * they can drive the standard PKCE flow when no Bearer is present.
+   * Defaults to `FERRLABS_AUTH_URL` env or `https://auth.ferrlabs.com`.
+   */
+  authorizationServer?: string;
 }
 
 async function readJsonBody(req: IncomingMessage): Promise<unknown | undefined> {
@@ -42,9 +56,50 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown | undefined> 
 
 export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
   const { port, host = '0.0.0.0', stateless = true } = opts;
+  const authServer =
+    opts.authorizationServer ?? process.env.FERRLABS_AUTH_URL ?? 'https://auth.ferrlabs.com';
   const transports = new Map<string, StreamableHTTPServerTransport>();
 
+  function sendUnauthorized(req: IncomingMessage, res: ServerResponse): void {
+    const origin = publicOrigin(req);
+    const metadataUrl = `${origin}/.well-known/oauth-protected-resource`;
+    res.writeHead(401, {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate': `Bearer resource_metadata="${metadataUrl}"`,
+    });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: -32001,
+          message:
+            'Missing or invalid bearer token. The MCP client should fetch the OAuth protected-resource metadata and run the authorization code + PKCE flow.',
+        },
+        id: null,
+      }),
+    );
+  }
+
+  function sendResourceMetadata(req: IncomingMessage, res: ServerResponse): void {
+    const origin = publicOrigin(req);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        resource: origin,
+        authorization_servers: [authServer],
+        bearer_methods_supported: ['header'],
+        resource_documentation: 'https://ferrlabs.com',
+      }),
+    );
+  }
+
   async function handleMcpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const bearerToken = extractBearer(req);
+    if (!bearerToken) {
+      sendUnauthorized(req, res);
+      return;
+    }
+
     const sessionId = (req.headers['mcp-session-id'] as string | undefined) ?? undefined;
     let transport = sessionId ? transports.get(sessionId) : undefined;
 
@@ -82,7 +137,6 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
     }
 
     const body = await readJsonBody(req);
-    const bearerToken = extractBearer(req);
     await runWithAuthContext({ bearerToken }, () => transport.handleRequest(req, res, body));
   }
 
@@ -91,6 +145,10 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
     if (url === '/health' || url === '/livez' || url === '/readyz') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ status: 'ok', service: 'ferrlabs-mcp' }));
+      return;
+    }
+    if (url === '/.well-known/oauth-protected-resource') {
+      sendResourceMetadata(req, res);
       return;
     }
     if (url === '/mcp' || url.startsWith('/mcp?')) {


### PR DESCRIPTION
Implements the MCP spec OAuth handshake on the HTTP transport. When a client (Claude Code, Cursor, …) hits `mcp.ferrlabs.com` without a Bearer token, the server now returns **401 + `WWW-Authenticate: Bearer resource_metadata="..."`** pointing at `/.well-known/oauth-protected-resource`. The client follows the link, discovers the FerrLabs auth server (`auth.ferrlabs.com`), runs OAuth 2.1 + PKCE, then retries the original request with the new Bearer.

End result: user adds the MCP to their Claude config with **no token**, restarts Claude, calls a tool → browser opens for consent → token captured client-side → subsequent calls work. No more manual token-pasting in env vars.

## What changed

`packages/mcp-core/src/transports/http.ts`:
- New `GET /.well-known/oauth-protected-resource` endpoint (RFC 9728)
  - Returns `{resource, authorization_servers: ["https://auth.ferrlabs.com"], bearer_methods_supported: ["header"]}`
  - Auth server URL configurable via `FERRLABS_AUTH_URL` env or `authorizationServer` runMcp option
- POST /mcp without/invalid `Authorization: Bearer` → **401** with WWW-Authenticate header pointing at the metadata URL
- Existing flows with a valid Bearer are unchanged (no regression for env-var/CI users)

## Tested locally

```
GET /.well-known/oauth-protected-resource → 200, returns metadata
POST /mcp (no Bearer)                     → 401 + WWW-Authenticate header
POST /mcp (with Bearer fft_…)             → 200, handshake proceeds
```

## Caveat / follow-up

The MCP client expects the authorization server to expose standard OAuth 2.1 endpoints (RFC 8414) at `<auth_server>/.well-known/oauth-authorization-server`. Our `api.ferrlabs.com` exposes OIDC discovery at `/.well-known/openid-configuration` which Claude Code may also accept (OIDC is OAuth-compatible). If discovery fails, a small follow-up on `FerrLabs-Cloud/api` to also serve the RFC 8414 alias would close the gap.

The token-exchange endpoint name is also non-standard (`/v1/auth/exchange` instead of the conventional `/token`). If MCP clients are strict about this, we add an alias on the API side.