### PR TITLE
fix(http): point OAuth discovery at api.ferrlabs.com (real metadata host)

### DIFF
--- a/packages/mcp-core/src/transports/http.ts
+++ b/packages/mcp-core/src/transports/http.ts
@@ -31,7 +31,14 @@ export interface HttpServerOptions {
    * URL of the OAuth 2.0 Authorization Server users authenticate against.
    * Surfaced to MCP clients via /.well-known/oauth-protected-resource so
    * they can drive the standard PKCE flow when no Bearer is present.
-   * Defaults to `FERRLABS_AUTH_URL` env or `https://auth.ferrlabs.com`.
+   *
+   * Must be the host that serves the OIDC / OAuth 2.0 discovery metadata
+   * (i.e. `<host>/.well-known/openid-configuration` or
+   * `<host>/.well-known/oauth-authorization-server`). For FerrLabs that's
+   * `api.ferrlabs.com` — `auth.ferrlabs.com` is the user-facing login SPA
+   * but doesn't serve the metadata documents.
+   *
+   * Defaults to `FERRLABS_AUTH_URL` env or `https://api.ferrlabs.com`.
    */
   authorizationServer?: string;
 }
@@ -57,7 +64,7 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown | undefined> 
 export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
   const { port, host = '0.0.0.0', stateless = true } = opts;
   const authServer =
-    opts.authorizationServer ?? process.env.FERRLABS_AUTH_URL ?? 'https://auth.ferrlabs.com';
+    opts.authorizationServer ?? process.env.FERRLABS_AUTH_URL ?? 'https://api.ferrlabs.com';
   const transports = new Map<string, StreamableHTTPServerTransport>();
 
   function sendUnauthorized(req: IncomingMessage, res: ServerResponse): void {


### PR DESCRIPTION
Investigating why `mcp.ferrlabs.com` clients couldn't complete the OAuth flow, I found that the protected-resource metadata was pointing at `auth.ferrlabs.com` as the authorization server, but **auth.ferrlabs.com is an SPA**, not the OAuth metadata host — fetching its `/.well-known/oauth-authorization-server` returns the SPA's index.html fallback.

The actual OIDC/OAuth discovery document lives at `https://api.ferrlabs.com/.well-known/openid-configuration` (verified: returns proper JSON with `issuer`, `authorization_endpoint`, `token_endpoint`, etc.).

## Fix

Change the default `authorizationServer` from `https://auth.ferrlabs.com` to `https://api.ferrlabs.com`. MCP clients will now find the metadata, then follow `authorization_endpoint` (a separate URL) to drive the user-facing browser flow.

## Open follow-up on FerrLabs-Cloud

The OIDC metadata currently has:
- `authorization_endpoint: https://api.ferrlabs.com/v1/auth/authorize` — this is the **API JSON endpoint** that requires an existing session, not a user-facing HTML page.
- `token_endpoint: https://api.ferrlabs.com/v1/auth/exchange` — JSON body only, no `application/x-www-form-urlencoded` support.

For the MCP browser-driven OAuth flow to actually complete, the API needs to:
1. Change `authorization_endpoint` to `https://auth.ferrlabs.com/authorize` (the SPA URL that handles consent UI)
2. Make `token_endpoint` accept form-encoded bodies (OAuth 2.0 standard) — either by modifying `/v1/auth/exchange` or adding a `POST /token` alias

Will track that in a separate issue on FerrLabs-Cloud after this lands.