### PR TITLE
feat(mcp): broaden sub-MCP tool surfaces across vault, track, growth, fleet

### DIFF
--- a/packages/mcp-fleet/src/tools/agents.ts
+++ b/packages/mcp-fleet/src/tools/agents.ts
@@ -43,4 +43,36 @@ export function registerAgentTools(server: McpServer) {
       };
     },
   );
+
+  server.tool(
+    'trigger_agent_run',
+    'Trigger a new run of a FerrFleet agent. Returns the freshly-created run id — poll get_run for status or pull get_run_transcript when finished.',
+    {
+      agent_id: z.string().min(1).describe('Agent id'),
+      input: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe('Optional structured input passed to the agent at run start.'),
+      reason: z
+        .string()
+        .max(500)
+        .optional()
+        .describe('Free-text reason recorded with the run (audit trail).'),
+    },
+    async ({ agent_id, input, reason }) => {
+      const token = await getToken();
+      const run = await apiRequest<{ id: string; status: string; created_at: string }>(
+        `/v1/agents/${encodeURIComponent(agent_id)}/runs`,
+        {
+          token,
+          method: 'POST',
+          baseUrl: FLEET_API_URL,
+          body: { input: input ?? {}, reason: reason ?? null },
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(run, null, 2) }],
+      };
+    },
+  );
 }

--- a/packages/mcp-fleet/src/tools/runs.ts
+++ b/packages/mcp-fleet/src/tools/runs.ts
@@ -40,7 +40,7 @@ export function registerRunTools(server: McpServer) {
 
   server.tool(
     'get_run',
-    'Get details + transcript of a single FerrFleet run.',
+    'Get the metadata of a single FerrFleet run (status, timing, agent, trigger). Use get_run_transcript for the captured output.',
     {
       run_id: z.string().min(1).describe('Run id'),
     },
@@ -52,6 +52,24 @@ export function registerRunTools(server: McpServer) {
       });
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(run, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'get_run_transcript',
+    'Get the full captured transcript of a FerrFleet run — every event the runner emitted, in order. Heavy for long runs; consider get_run first to confirm the run is interesting before pulling the transcript.',
+    {
+      run_id: z.string().min(1).describe('Run id'),
+    },
+    async ({ run_id }) => {
+      const token = await getToken();
+      const transcript = await apiRequest<unknown>(
+        `/v1/runs/${encodeURIComponent(run_id)}/transcript`,
+        { token, baseUrl: FLEET_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(transcript, null, 2) }],
       };
     },
   );

--- a/packages/mcp-growth/src/index.ts
+++ b/packages/mcp-growth/src/index.ts
@@ -2,6 +2,9 @@
 import { runMcp } from '@ferrlabs/mcp-core';
 import { registerSiteTools } from './tools/sites.js';
 import { registerPageTools } from './tools/pages.js';
+import { registerFormTools } from './tools/forms.js';
+import { registerAnalyticsTools } from './tools/analytics.js';
+import { registerSeoTools } from './tools/seo.js';
 
 runMcp({
   name: 'ferrlabs-growth',
@@ -9,6 +12,9 @@ runMcp({
   register: (server) => {
     registerSiteTools(server);
     registerPageTools(server);
+    registerFormTools(server);
+    registerAnalyticsTools(server);
+    registerSeoTools(server);
   },
 }).catch((err: unknown) => {
   console.error('ferrlabs-mcp-growth fatal:', err instanceof Error ? err.message : err);

--- a/packages/mcp-growth/src/tools/analytics.ts
+++ b/packages/mcp-growth/src/tools/analytics.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { GROWTH_API_URL } from '../api-base.js';
+
+interface AnalyticsSummary {
+  site_id: string;
+  range: { from: string; to: string };
+  total_visits: number;
+  unique_visitors: number;
+  top_pages: Array<{ path: string; visits: number }>;
+  top_referrers: Array<{ source: string; visits: number }>;
+}
+
+export function registerAnalyticsTools(server: McpServer) {
+  server.tool(
+    'get_analytics_summary',
+    "Visit + referrer summary for a FerrGrowth site. Optional ISO date range, otherwise the API's default window applies.",
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      from: z
+        .string()
+        .optional()
+        .describe('ISO 8601 start (e.g. 2026-05-01). Defaults to last 30 days.'),
+      to: z.string().optional().describe('ISO 8601 end (e.g. 2026-05-22).'),
+    },
+    async ({ site_id, from, to }) => {
+      const token = await getToken();
+      const params = new URLSearchParams();
+      if (from) params.set('from', from);
+      if (to) params.set('to', to);
+      const qs = params.toString() ? `?${params.toString()}` : '';
+      const summary = await apiRequest<AnalyticsSummary>(
+        `/v1/sites/${encodeURIComponent(site_id)}/analytics${qs}`,
+        { token, baseUrl: GROWTH_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-growth/src/tools/forms.ts
+++ b/packages/mcp-growth/src/tools/forms.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { GROWTH_API_URL } from '../api-base.js';
+
+interface Form {
+  id: string;
+  site_id: string;
+  name: string;
+  fields: Array<{ name: string; type: string; required: boolean }>;
+  created_at: string;
+  updated_at: string;
+}
+
+interface FormSubmission {
+  id: string;
+  form_id: string;
+  values: Record<string, unknown>;
+  ip: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+export function registerFormTools(server: McpServer) {
+  server.tool(
+    'list_forms',
+    'List forms attached to a FerrGrowth site.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+    },
+    async ({ site_id }) => {
+      const token = await getToken();
+      const forms = await apiRequest<Form[]>(`/v1/sites/${encodeURIComponent(site_id)}/forms`, {
+        token,
+        baseUrl: GROWTH_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(forms, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'list_form_submissions',
+    'List submissions for a FerrGrowth form, most recent first.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      form_id: z.string().min(1).describe('Form id'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .optional()
+        .describe('Max submissions to return (default 50).'),
+    },
+    async ({ site_id, form_id, limit }) => {
+      const token = await getToken();
+      const qs = limit !== undefined ? `?limit=${limit}` : '';
+      const subs = await apiRequest<FormSubmission[]>(
+        `/v1/sites/${encodeURIComponent(site_id)}/forms/${encodeURIComponent(form_id)}/submissions${qs}`,
+        { token, baseUrl: GROWTH_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(subs, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-growth/src/tools/pages.ts
+++ b/packages/mcp-growth/src/tools/pages.ts
@@ -17,7 +17,7 @@ export function registerPageTools(server: McpServer) {
     'list_pages',
     'List pages on a FerrGrowth site.',
     {
-      site_id: z.string().min(1).describe('Site id'),
+      site_id: z.string().min(1).describe('Site id or slug'),
     },
     async ({ site_id }) => {
       const token = await getToken();
@@ -27,6 +27,44 @@ export function registerPageTools(server: McpServer) {
       });
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(pages, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'get_page',
+    'Get a single FerrGrowth page (full content + metadata).',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      page_slug: z.string().min(1).describe('Page slug'),
+    },
+    async ({ site_id, page_slug }) => {
+      const token = await getToken();
+      const page = await apiRequest<Page>(
+        `/v1/sites/${encodeURIComponent(site_id)}/pages/${encodeURIComponent(page_slug)}`,
+        { token, baseUrl: GROWTH_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(page, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'publish_page',
+    "Publish a FerrGrowth page — flips it live on the site's active release. Idempotent: re-publishing an already-live page is a no-op.",
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      page_slug: z.string().min(1).describe('Page slug'),
+    },
+    async ({ site_id, page_slug }) => {
+      const token = await getToken();
+      const page = await apiRequest<Page>(
+        `/v1/sites/${encodeURIComponent(site_id)}/pages/${encodeURIComponent(page_slug)}/publish`,
+        { token, method: 'POST', baseUrl: GROWTH_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(page, null, 2) }],
       };
     },
   );

--- a/packages/mcp-growth/src/tools/seo.ts
+++ b/packages/mcp-growth/src/tools/seo.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { GROWTH_API_URL } from '../api-base.js';
+
+interface SeoOverview {
+  site_id: string;
+  pages_audited: number;
+  average_score: number | null;
+  worst_pages: Array<{ page_slug: string; score: number; issues: number }>;
+}
+
+interface SeoAuditResult {
+  id: string;
+  site_id: string;
+  page_slug: string;
+  score: number;
+  issues: Array<{ severity: string; rule: string; message: string }>;
+  created_at: string;
+}
+
+export function registerSeoTools(server: McpServer) {
+  server.tool(
+    'get_seo_overview',
+    'Aggregated SEO scores across all audited pages of a FerrGrowth site, with the worst offenders listed.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+    },
+    async ({ site_id }) => {
+      const token = await getToken();
+      const overview = await apiRequest<SeoOverview>(
+        `/v1/sites/${encodeURIComponent(site_id)}/audits/seo/overview`,
+        { token, baseUrl: GROWTH_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(overview, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'run_seo_audit',
+    'Run a fresh SEO audit on a single FerrGrowth page. Returns the score plus a list of issues by severity.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      page_slug: z.string().min(1).describe('Page slug'),
+    },
+    async ({ site_id, page_slug }) => {
+      const token = await getToken();
+      const result = await apiRequest<SeoAuditResult>(
+        `/v1/sites/${encodeURIComponent(site_id)}/pages/${encodeURIComponent(page_slug)}/audits/seo`,
+        { token, method: 'POST', baseUrl: GROWTH_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-track/src/index.ts
+++ b/packages/mcp-track/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { runMcp } from '@ferrlabs/mcp-core';
 import { registerIssueDetailsTool } from './tools/issue-details.js';
+import { registerIssueTools } from './tools/issues.js';
 import { registerLabelTools } from './tools/labels.js';
 import { registerCommentTools } from './tools/comments.js';
 
@@ -9,6 +10,7 @@ runMcp({
   version: '6.0.0',
   register: (server) => {
     registerIssueDetailsTool(server);
+    registerIssueTools(server);
     registerLabelTools(server);
     registerCommentTools(server);
   },

--- a/packages/mcp-track/src/tools/comments.ts
+++ b/packages/mcp-track/src/tools/comments.ts
@@ -30,4 +30,25 @@ export function registerCommentTools(server: McpServer) {
       };
     },
   );
+
+  server.tool(
+    'create_issue_comment',
+    'Post a new comment on a FerrTrack issue. Body supports markdown.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      number: z.number().int().min(1).describe('Issue number'),
+      body: z.string().min(1).describe('Comment body (markdown).'),
+    },
+    async ({ org_slug, project_slug, number, body }) => {
+      const token = await getToken();
+      const comment = await apiRequest<Comment>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/issues/${number}/comments`,
+        { token, method: 'POST', body: { body } },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(comment, null, 2) }],
+      };
+    },
+  );
 }

--- a/packages/mcp-track/src/tools/issues.ts
+++ b/packages/mcp-track/src/tools/issues.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+
+interface IssueSummary {
+  id: string;
+  number: number;
+  title: string;
+  state: string;
+  author_id: string;
+  assignee_id: string | null;
+  labels: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export function registerIssueTools(server: McpServer) {
+  server.tool(
+    'list_issues',
+    'List FerrTrack issues in a project. Supports filtering by state, label, and assignee, plus a pagination limit.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      state: z
+        .enum(['open', 'closed', 'all'])
+        .optional()
+        .describe('Filter by issue state (default open).'),
+      label: z.string().optional().describe('Only return issues carrying this label name.'),
+      assignee_id: z.string().optional().describe('Only return issues assigned to this user id.'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('Max issues to return (default 30).'),
+    },
+    async ({ org_slug, project_slug, state, label, assignee_id, limit }) => {
+      const token = await getToken();
+      const params = new URLSearchParams();
+      if (state) params.set('state', state);
+      if (label) params.set('label', label);
+      if (assignee_id) params.set('assignee_id', assignee_id);
+      if (limit !== undefined) params.set('limit', String(limit));
+      const qs = params.toString() ? `?${params.toString()}` : '';
+      const issues = await apiRequest<IssueSummary[]>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/issues${qs}`,
+        { token },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(issues, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'create_issue',
+    'Create a new FerrTrack issue. Returns the newly assigned issue number.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      title: z.string().min(1).max(255).describe('Issue title'),
+      body: z.string().optional().describe('Issue body (markdown).'),
+      labels: z.array(z.string()).optional().describe('Label names to apply on creation.'),
+      assignee_id: z.string().optional().describe('User id to assign on creation.'),
+    },
+    async ({ org_slug, project_slug, title, body, labels, assignee_id }) => {
+      const token = await getToken();
+      const issue = await apiRequest<IssueSummary>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/issues`,
+        {
+          token,
+          method: 'POST',
+          body: {
+            title,
+            body: body ?? null,
+            labels: labels ?? [],
+            assignee_id: assignee_id ?? null,
+          },
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(issue, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'update_issue',
+    'Patch a FerrTrack issue — change title/body, flip state (open↔closed), or update labels/assignee. Only fields you pass are touched.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      number: z.number().int().min(1).describe('Issue number'),
+      title: z.string().min(1).max(255).optional(),
+      body: z.string().optional(),
+      state: z.enum(['open', 'closed']).optional(),
+      labels: z.array(z.string()).optional(),
+      assignee_id: z.string().nullable().optional().describe('Pass null to unassign.'),
+    },
+    async ({ org_slug, project_slug, number, ...patch }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const issue = await apiRequest<IssueSummary>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/issues/${number}`,
+        { token, method: 'PATCH', body },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(issue, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-vault/src/index.ts
+++ b/packages/mcp-vault/src/index.ts
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 import { runMcp } from '@ferrlabs/mcp-core';
 import { registerVaultDetailsTool } from './tools/vault-details.js';
+import { registerSecretTools } from './tools/secrets.js';
+import { registerVaultAuditTools } from './tools/audit.js';
+import { registerVaultMutationTools } from './tools/vaults.js';
 
 runMcp({
   name: 'ferrlabs-vault',
   version: '5.2.5',
   register: (server) => {
     registerVaultDetailsTool(server);
+    registerSecretTools(server);
+    registerVaultAuditTools(server);
+    registerVaultMutationTools(server);
   },
 }).catch((err: unknown) => {
   console.error('ferrlabs-mcp-vault fatal:', err instanceof Error ? err.message : err);

--- a/packages/mcp-vault/src/tools/audit.ts
+++ b/packages/mcp-vault/src/tools/audit.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+
+interface AuditEntry {
+  id: string;
+  actor_id: string;
+  action: string;
+  target_id: string | null;
+  details: Record<string, unknown> | null;
+  created_at: string;
+}
+
+interface SecretRequest {
+  id: string;
+  vault_id: string;
+  requested_name: string;
+  requester_id: string;
+  status: string;
+  created_at: string;
+  archived_at: string | null;
+}
+
+export function registerVaultAuditTools(server: McpServer) {
+  server.tool(
+    'get_vault_audit_log',
+    'Recent audit-log entries for a FerrVault vault — who read/wrote/rotated what, when.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(200)
+        .optional()
+        .describe('Max entries to return (default 50).'),
+    },
+    async ({ org_slug, project_slug, vault_id, limit }) => {
+      const token = await getToken();
+      const qs = limit !== undefined ? `?limit=${limit}` : '';
+      const entries = await apiRequest<AuditEntry[]>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/vaults/${encodeURIComponent(vault_id)}/audit-log${qs}`,
+        { token },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(entries, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'list_secret_requests',
+    'List pending "missing secret" requests filed by operators/SDKs when a name lookup misses. Useful to spot secrets that need to be provisioned.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+    },
+    async ({ org_slug, project_slug, vault_id }) => {
+      const token = await getToken();
+      const requests = await apiRequest<SecretRequest[]>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/vaults/${encodeURIComponent(vault_id)}/secret-requests`,
+        { token },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(requests, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-vault/src/tools/secrets.ts
+++ b/packages/mcp-vault/src/tools/secrets.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+
+interface SecretSummary {
+  id: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  rotated_at: string | null;
+}
+
+interface SecretRevealed extends SecretSummary {
+  value: string;
+}
+
+export function registerSecretTools(server: McpServer) {
+  server.tool(
+    'list_secrets',
+    'List secrets inside a FerrVault vault. Values are NOT included — use get_secret with reveal=true to see a specific value.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+    },
+    async ({ org_slug, project_slug, vault_id }) => {
+      const token = await getToken();
+      const secrets = await apiRequest<SecretSummary[]>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/vaults/${encodeURIComponent(vault_id)}/secrets`,
+        { token },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(secrets, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'get_secret',
+    'Get one secret. By default returns metadata only; pass reveal=true to also include the decrypted value (audit-logged on the server).',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+      secret_id: z.string().min(1).describe('Secret id'),
+      reveal: z
+        .boolean()
+        .optional()
+        .describe('Include the decrypted value in the response (default false).'),
+    },
+    async ({ org_slug, project_slug, vault_id, secret_id, reveal }) => {
+      const token = await getToken();
+      const qs = reveal ? '?reveal=true' : '';
+      const secret = await apiRequest<SecretRevealed>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/vaults/${encodeURIComponent(vault_id)}/secrets/${encodeURIComponent(secret_id)}${qs}`,
+        { token },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(secret, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-vault/src/tools/vaults.ts
+++ b/packages/mcp-vault/src/tools/vaults.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+
+interface VaultSummary {
+  id: string;
+  name: string;
+  description: string | null;
+  secret_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export function registerVaultMutationTools(server: McpServer) {
+  server.tool(
+    'create_vault',
+    'Create a new vault inside a project. Empty by default — populate via the FerrVault app or via secret-request workflows.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      name: z.string().min(1).max(100).describe('Human-readable vault name'),
+      description: z.string().max(500).optional().describe('Optional description for teammates'),
+    },
+    async ({ org_slug, project_slug, name, description }) => {
+      const token = await getToken();
+      const vault = await apiRequest<VaultSummary>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/vaults`,
+        {
+          token,
+          method: 'POST',
+          body: { name, description: description ?? null },
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(vault, null, 2) }],
+      };
+    },
+  );
+}


### PR DESCRIPTION
Closes #140. Adds high-value tools to each sub-MCP, mixing reads with low-risk writes. Existing tools unchanged. Vault: list_secrets, get_secret (with reveal flag), get_vault_audit_log, list_secret_requests, create_vault. Track: list_issues with filters, create_issue, update_issue, create_issue_comment. Growth: get_page, publish_page, list_forms, list_form_submissions, get_analytics_summary, get_seo_overview, run_seo_audit. Fleet: trigger_agent_run, get_run_transcript. Verification: pnpm typecheck clean, pnpm test 20/20 green. Builds on top of FerrLabs/MCP#139 (401 auto-recovery) and FerrLabs/FerrLabs-Cloud#339 (exchange mints API tokens), no dependency on either.