### PR TITLE
fix(mcp-core): handle CORS preflight so browser clients can authenticate

### DIFF
--- a/packages/mcp-core/src/transports/http.ts
+++ b/packages/mcp-core/src/transports/http.ts
@@ -147,7 +147,29 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
     await runWithAuthContext({ bearerToken }, () => transport.handleRequest(req, res, body));
   }
 
+  function applyCorsHeaders(req: IncomingMessage, res: ServerResponse): void {
+    const origin = (req.headers.origin as string | undefined) ?? '*';
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    const requested =
+      (req.headers['access-control-request-headers'] as string | undefined) ??
+      'authorization, content-type, mcp-session-id, mcp-protocol-version';
+    res.setHeader('Access-Control-Allow-Headers', requested);
+    res.setHeader('Access-Control-Expose-Headers', 'mcp-session-id, www-authenticate');
+    res.setHeader('Access-Control-Max-Age', '86400');
+  }
+
   const httpServer = createHttpServer((req, res) => {
+    applyCorsHeaders(req, res);
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
     const url = req.url ?? '/';
     if (url === '/health' || url === '/livez' || url === '/readyz') {
       res.writeHead(200, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary

OPTIONS preflight requests on \`/mcp\` were hitting the same auth-required code path as regular requests, so the server returned \`401 Unauthorized\` instead of a 204 with CORS headers. Any browser-based MCP client (Claude's Connectors picker, the Anthropic dashboard) refused to even attempt the actual MCP call — the preflight failed, so the request never went out.

Symptom: connecting \`https://mcp.ferrlabs.com/mcp\` from the Claude Connectors UI produces *"Couldn't reach the MCP server"* even though \`curl\` confirms the server is up, \`/health\` returns 200, and \`POST /mcp\` returns a spec-compliant \`401 + WWW-Authenticate\`.

## Fix

In \`mcp-core/transports/http.ts\`, set the CORS headers on every response and short-circuit \`OPTIONS\` with a \`204\` *before* any of the route / auth handling runs:

- \`Access-Control-Allow-Origin\`: echoes the request origin (falling back to \`*\`)
- \`Access-Control-Allow-Credentials: true\`
- \`Access-Control-Allow-Methods: GET, POST, OPTIONS\`
- \`Access-Control-Allow-Headers\`: echoes \`Access-Control-Request-Headers\` so the MCP SDK's custom \`mcp-session-id\` / \`mcp-protocol-version\` headers pass through
- \`Access-Control-Expose-Headers: mcp-session-id, www-authenticate\` so the client can read the auth challenge and the session id
- \`Access-Control-Max-Age: 86400\` so the preflight is cached for a day

## Test plan

- [x] \`pnpm -r build\` passes
- [x] \`pnpm test\` — 22 tests pass
- [ ] Manual smoke: \`curl -X OPTIONS https://mcp.ferrlabs.com/mcp -H "Origin: https://claude.ai" …\` returns 204 + the Allow-* headers
- [ ] Connect \`mcp.ferrtrack.com\` via the Claude Connectors picker, complete OAuth, call \`list_projects\`