### PR TITLE
feat(mcp): round out CRUD across vault, track, growth sub-MCPs

### DIFF
--- a/packages/mcp-growth/src/index.ts
+++ b/packages/mcp-growth/src/index.ts
@@ -5,6 +5,7 @@ import { registerPageTools } from './tools/pages.js';
 import { registerFormTools } from './tools/forms.js';
 import { registerAnalyticsTools } from './tools/analytics.js';
 import { registerSeoTools } from './tools/seo.js';
+import { registerReleaseTools } from './tools/releases.js';
 
 runMcp({
   name: 'ferrlabs-growth',
@@ -15,6 +16,7 @@ runMcp({
     registerFormTools(server);
     registerAnalyticsTools(server);
     registerSeoTools(server);
+    registerReleaseTools(server);
   },
 }).catch((err: unknown) => {
   console.error('ferrlabs-mcp-growth fatal:', err instanceof Error ? err.message : err);

--- a/packages/mcp-growth/src/tools/forms.ts
+++ b/packages/mcp-growth/src/tools/forms.ts
@@ -65,4 +65,91 @@ export function registerFormTools(server: McpServer) {
       };
     },
   );
+
+  server.tool(
+    'create_form',
+    'Create a new form on a FerrGrowth site. Fields are typed; submissions land in list_form_submissions.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      name: z.string().min(1).max(100),
+      fields: z
+        .array(
+          z.object({
+            name: z
+              .string()
+              .min(1)
+              .max(80)
+              .regex(/^[a-z][a-z0-9_]*$/, 'snake_case identifier'),
+            type: z.enum(['text', 'email', 'phone', 'textarea', 'select', 'checkbox', 'number']),
+            required: z.boolean().optional(),
+          }),
+        )
+        .min(1)
+        .describe('Form schema — at least one field.'),
+    },
+    async ({ site_id, name, fields }) => {
+      const token = await getToken();
+      const form = await apiRequest<Form>(`/v1/sites/${encodeURIComponent(site_id)}/forms`, {
+        token,
+        baseUrl: GROWTH_API_URL,
+        method: 'POST',
+        body: { name, fields },
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(form, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'update_form',
+    'Patch a FerrGrowth form — rename it or replace the field schema. Only fields you pass are touched.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      form_id: z.string().min(1).describe('Form id'),
+      name: z.string().min(1).max(100).optional(),
+      fields: z
+        .array(
+          z.object({
+            name: z.string().min(1).max(80),
+            type: z.enum(['text', 'email', 'phone', 'textarea', 'select', 'checkbox', 'number']),
+            required: z.boolean().optional(),
+          }),
+        )
+        .optional(),
+    },
+    async ({ site_id, form_id, ...patch }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const form = await apiRequest<Form>(
+        `/v1/sites/${encodeURIComponent(site_id)}/forms/${encodeURIComponent(form_id)}`,
+        { token, baseUrl: GROWTH_API_URL, method: 'PATCH', body },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(form, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'delete_form',
+    'Delete a FerrGrowth form. Existing submissions are kept in the audit table; the form definition is removed.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      form_id: z.string().min(1).describe('Form id'),
+    },
+    async ({ site_id, form_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(
+        `/v1/sites/${encodeURIComponent(site_id)}/forms/${encodeURIComponent(form_id)}`,
+        { token, baseUrl: GROWTH_API_URL, method: 'DELETE' },
+      );
+      return {
+        content: [{ type: 'text' as const, text: `Form ${form_id} deleted.` }],
+      };
+    },
+  );
 }

--- a/packages/mcp-growth/src/tools/pages.ts
+++ b/packages/mcp-growth/src/tools/pages.ts
@@ -68,4 +68,124 @@ export function registerPageTools(server: McpServer) {
       };
     },
   );
+
+  server.tool(
+    'create_page',
+    'Create a new page on a FerrGrowth site. Newly created pages are unpublished by default — call publish_page when ready.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      slug: z
+        .string()
+        .min(1)
+        .max(80)
+        .regex(/^[a-z0-9/-]+$/, 'lowercase alphanumeric + slashes + hyphens'),
+      title: z.string().min(1).max(200),
+      content: z
+        .string()
+        .optional()
+        .describe('Initial markdown/MDX body. Optional — pages can start blank.'),
+    },
+    async ({ site_id, slug, title, content }) => {
+      const token = await getToken();
+      const page = await apiRequest<Page>(`/v1/sites/${encodeURIComponent(site_id)}/pages`, {
+        token,
+        baseUrl: GROWTH_API_URL,
+        method: 'POST',
+        body: { slug, title, content: content ?? '' },
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(page, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'update_page',
+    'Patch a FerrGrowth page — title, slug, or content. Only fields you pass are touched. Publishing remains via publish_page.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      page_slug: z.string().min(1).describe('Page slug'),
+      title: z.string().min(1).max(200).optional(),
+      new_slug: z
+        .string()
+        .min(1)
+        .max(80)
+        .regex(/^[a-z0-9/-]+$/)
+        .optional()
+        .describe('Rename the page slug (and its URL).'),
+      content: z.string().optional(),
+    },
+    async ({ site_id, page_slug, new_slug, ...rest }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      if (new_slug !== undefined) body.slug = new_slug;
+      for (const [k, v] of Object.entries(rest)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const page = await apiRequest<Page>(
+        `/v1/sites/${encodeURIComponent(site_id)}/pages/${encodeURIComponent(page_slug)}`,
+        { token, baseUrl: GROWTH_API_URL, method: 'PATCH', body },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(page, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'discover_pages',
+    'Crawl a URL and discover candidate pages to import into a FerrGrowth site (sitemap / link graph). Returns a list of candidate page slugs + titles; no pages are created yet — feed the result to import_pages.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      url: z.string().url().describe('Origin URL to crawl.'),
+    },
+    async ({ site_id, url }) => {
+      const token = await getToken();
+      const result = await apiRequest<unknown>(
+        `/v1/sites/${encodeURIComponent(site_id)}/pages/discover`,
+        {
+          token,
+          baseUrl: GROWTH_API_URL,
+          method: 'POST',
+          body: { url },
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'import_pages',
+    'Import the pages discovered by discover_pages into the site. Each item creates an unpublished page; review then publish_page when ready.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      pages: z
+        .array(
+          z.object({
+            url: z.string().url(),
+            slug: z.string().min(1).max(80),
+            title: z.string().min(1).max(200),
+          }),
+        )
+        .min(1)
+        .describe('Pages to import (typically the output of discover_pages).'),
+    },
+    async ({ site_id, pages }) => {
+      const token = await getToken();
+      const result = await apiRequest<unknown>(
+        `/v1/sites/${encodeURIComponent(site_id)}/pages/import`,
+        {
+          token,
+          baseUrl: GROWTH_API_URL,
+          method: 'POST',
+          body: { pages },
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
 }

--- a/packages/mcp-growth/src/tools/releases.ts
+++ b/packages/mcp-growth/src/tools/releases.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { GROWTH_API_URL } from '../api-base.js';
+
+interface Release {
+  id: string;
+  site_id: string;
+  version: string;
+  active: boolean;
+  size_bytes: number;
+  created_at: string;
+}
+
+export function registerReleaseTools(server: McpServer) {
+  server.tool(
+    'list_releases',
+    'List bundle releases of a FerrGrowth site (built artefacts). The one with `active: true` is the one currently served.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+    },
+    async ({ site_id }) => {
+      const token = await getToken();
+      const releases = await apiRequest<Release[]>(
+        `/v1/sites/${encodeURIComponent(site_id)}/releases`,
+        { token, baseUrl: GROWTH_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(releases, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'activate_release',
+    'Switch the live serving release for a FerrGrowth site to a specific release id (rollback or roll-forward). Atomic — no downtime.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      release_id: z.string().min(1).describe('Release id'),
+    },
+    async ({ site_id, release_id }) => {
+      const token = await getToken();
+      const release = await apiRequest<Release>(
+        `/v1/sites/${encodeURIComponent(site_id)}/releases/${encodeURIComponent(release_id)}/activate`,
+        { token, baseUrl: GROWTH_API_URL, method: 'POST' },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(release, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-growth/src/tools/sites.ts
+++ b/packages/mcp-growth/src/tools/sites.ts
@@ -30,7 +30,7 @@ export function registerSiteTools(server: McpServer) {
     'get_site',
     'Get details for a single FerrGrowth site (status, custom domain, etc.).',
     {
-      site_id: z.string().min(1).describe('Site id'),
+      site_id: z.string().min(1).describe('Site id or slug'),
     },
     async ({ site_id }) => {
       const token = await getToken();
@@ -40,6 +40,143 @@ export function registerSiteTools(server: McpServer) {
       });
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(site, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'create_site',
+    'Create a new FerrGrowth site. The slug becomes the default `<slug>.ferrgrowth.app` subdomain until you attach a custom domain.',
+    {
+      slug: z
+        .string()
+        .min(2)
+        .max(40)
+        .regex(/^[a-z0-9-]+$/, 'lowercase alphanumeric + hyphens'),
+      name: z.string().min(1).max(100),
+    },
+    async ({ slug, name }) => {
+      const token = await getToken();
+      const site = await apiRequest<Site>('/v1/sites', {
+        token,
+        baseUrl: GROWTH_API_URL,
+        method: 'POST',
+        body: { slug, name },
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(site, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'update_site',
+    'Rename a FerrGrowth site or change its slug. Slug changes also move the default subdomain.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      slug: z
+        .string()
+        .min(2)
+        .max(40)
+        .regex(/^[a-z0-9-]+$/)
+        .optional(),
+      name: z.string().min(1).max(100).optional(),
+    },
+    async ({ site_id, ...patch }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const site = await apiRequest<Site>(`/v1/sites/${encodeURIComponent(site_id)}`, {
+        token,
+        baseUrl: GROWTH_API_URL,
+        method: 'PATCH',
+        body,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(site, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'archive_site',
+    "Archive a FerrGrowth site — takes it offline and stops serving its custom domain. Reversible via the dashboard; this MCP doesn't expose unarchive.",
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+    },
+    async ({ site_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(`/v1/sites/${encodeURIComponent(site_id)}`, {
+        token,
+        baseUrl: GROWTH_API_URL,
+        method: 'DELETE',
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Site ${site_id} archived.` }],
+      };
+    },
+  );
+
+  server.tool(
+    'attach_domain',
+    'Attach a custom domain to a FerrGrowth site. The domain is registered in the pending state until verify_domain succeeds — DNS-01 verification via a TXT record.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      domain: z
+        .string()
+        .min(3)
+        .max(253)
+        .regex(/^[a-z0-9.-]+\.[a-z]{2,}$/i, 'looks like a valid domain'),
+    },
+    async ({ site_id, domain }) => {
+      const token = await getToken();
+      const result = await apiRequest<unknown>(`/v1/sites/${encodeURIComponent(site_id)}/domain`, {
+        token,
+        baseUrl: GROWTH_API_URL,
+        method: 'POST',
+        body: { domain },
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'verify_domain',
+    "Verify the custom domain previously attached to a FerrGrowth site. Checks the DNS TXT challenge — succeeds when the challenge matches, fails otherwise. Idempotent: retry after fixing DNS if it's not propagated yet.",
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+    },
+    async ({ site_id }) => {
+      const token = await getToken();
+      const result = await apiRequest<unknown>(
+        `/v1/sites/${encodeURIComponent(site_id)}/domain/verify`,
+        { token, baseUrl: GROWTH_API_URL, method: 'POST' },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'detach_domain',
+    'Detach the custom domain from a FerrGrowth site. The site falls back to its `<slug>.ferrgrowth.app` subdomain.',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+    },
+    async ({ site_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(`/v1/sites/${encodeURIComponent(site_id)}/domain`, {
+        token,
+        baseUrl: GROWTH_API_URL,
+        method: 'DELETE',
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Custom domain detached from ${site_id}.` }],
       };
     },
   );

--- a/packages/mcp-track/src/index.ts
+++ b/packages/mcp-track/src/index.ts
@@ -4,6 +4,9 @@ import { registerIssueDetailsTool } from './tools/issue-details.js';
 import { registerIssueTools } from './tools/issues.js';
 import { registerCommentTools } from './tools/comments.js';
 import { registerProjectTools } from './tools/projects.js';
+import { registerCycleTools } from './tools/cycles.js';
+import { registerMilestoneTools } from './tools/milestones.js';
+import { registerSearchTools } from './tools/search.js';
 
 runMcp({
   name: 'ferrlabs-track',
@@ -13,6 +16,9 @@ runMcp({
     registerIssueDetailsTool(server);
     registerIssueTools(server);
     registerCommentTools(server);
+    registerCycleTools(server);
+    registerMilestoneTools(server);
+    registerSearchTools(server);
   },
 }).catch((err: unknown) => {
   console.error('ferrlabs-mcp-track fatal:', err instanceof Error ? err.message : err);

--- a/packages/mcp-track/src/tools/comments.ts
+++ b/packages/mcp-track/src/tools/comments.ts
@@ -48,4 +48,43 @@ export function registerCommentTools(server: McpServer) {
       };
     },
   );
+
+  server.tool(
+    'update_issue_comment',
+    'Edit a comment you authored on a FerrTrack issue.',
+    {
+      issue_ref: z.string().min(1).describe('Issue ref, e.g. "FT-12"'),
+      comment_id: z.string().min(1).describe('Comment id'),
+      body: z.string().min(1).describe('New comment body (markdown).'),
+    },
+    async ({ issue_ref, comment_id, body }) => {
+      const token = await getToken();
+      const comment = await apiRequest<Comment>(
+        `/v1/issues/${encodeURIComponent(issue_ref)}/comments/${encodeURIComponent(comment_id)}`,
+        { token, baseUrl: TRACK_API_URL, method: 'PATCH', body: { body } },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(comment, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'delete_issue_comment',
+    'Delete a comment you authored on a FerrTrack issue.',
+    {
+      issue_ref: z.string().min(1).describe('Issue ref, e.g. "FT-12"'),
+      comment_id: z.string().min(1).describe('Comment id'),
+    },
+    async ({ issue_ref, comment_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(
+        `/v1/issues/${encodeURIComponent(issue_ref)}/comments/${encodeURIComponent(comment_id)}`,
+        { token, baseUrl: TRACK_API_URL, method: 'DELETE' },
+      );
+      return {
+        content: [{ type: 'text' as const, text: `Comment ${comment_id} deleted.` }],
+      };
+    },
+  );
 }

--- a/packages/mcp-track/src/tools/cycles.ts
+++ b/packages/mcp-track/src/tools/cycles.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { TRACK_API_URL } from '../api-base.js';
+
+interface Cycle {
+  id: string;
+  project_id: string;
+  number: number;
+  name: string;
+  starts_at: string;
+  ends_at: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface CycleIssue {
+  id: string;
+  ref: string;
+  title: string;
+  status: string;
+  assignee_id: string | null;
+}
+
+export function registerCycleTools(server: McpServer) {
+  server.tool(
+    'list_cycles',
+    'List cycles (sprints) for a FerrTrack project.',
+    {
+      project_slug: z.string().min(1).describe('Project slug'),
+    },
+    async ({ project_slug }) => {
+      const token = await getToken();
+      const cycles = await apiRequest<Cycle[]>(
+        `/v1/projects/${encodeURIComponent(project_slug)}/cycles`,
+        { token, baseUrl: TRACK_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(cycles, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'list_cycle_issues',
+    'List the issues currently assigned to a FerrTrack cycle.',
+    {
+      cycle_id: z.string().min(1).describe('Cycle id'),
+    },
+    async ({ cycle_id }) => {
+      const token = await getToken();
+      const issues = await apiRequest<CycleIssue[]>(
+        `/v1/cycles/${encodeURIComponent(cycle_id)}/issues`,
+        { token, baseUrl: TRACK_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(issues, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'create_cycle',
+    'Create a new cycle in a project. Dates are ISO 8601 (YYYY-MM-DD).',
+    {
+      project_slug: z.string().min(1).describe('Project slug'),
+      name: z.string().min(1).max(100),
+      starts_at: z.string().describe('ISO date — cycle start.'),
+      ends_at: z.string().describe('ISO date — cycle end.'),
+    },
+    async ({ project_slug, name, starts_at, ends_at }) => {
+      const token = await getToken();
+      const cycle = await apiRequest<Cycle>(
+        `/v1/projects/${encodeURIComponent(project_slug)}/cycles`,
+        {
+          token,
+          baseUrl: TRACK_API_URL,
+          method: 'POST',
+          body: { name, starts_at, ends_at },
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(cycle, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'plan_next_cycle',
+    'Trigger the auto-planner to generate the next cycle from the project backlog. Returns the newly created cycle.',
+    {
+      project_slug: z.string().min(1).describe('Project slug'),
+    },
+    async ({ project_slug }) => {
+      const token = await getToken();
+      const cycle = await apiRequest<Cycle>(
+        `/v1/projects/${encodeURIComponent(project_slug)}/cycles/plan`,
+        { token, baseUrl: TRACK_API_URL, method: 'POST' },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(cycle, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'update_cycle',
+    'Patch a cycle — rename it, shift dates, or close it. Only fields you pass are touched.',
+    {
+      cycle_id: z.string().min(1).describe('Cycle id'),
+      name: z.string().min(1).max(100).optional(),
+      starts_at: z.string().optional(),
+      ends_at: z.string().optional(),
+      status: z.enum(['planned', 'active', 'completed']).optional(),
+    },
+    async ({ cycle_id, ...patch }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const cycle = await apiRequest<Cycle>(`/v1/cycles/${encodeURIComponent(cycle_id)}`, {
+        token,
+        baseUrl: TRACK_API_URL,
+        method: 'PATCH',
+        body,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(cycle, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'delete_cycle',
+    'Delete a cycle. Issues that were on it become un-cycled.',
+    {
+      cycle_id: z.string().min(1).describe('Cycle id'),
+    },
+    async ({ cycle_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(`/v1/cycles/${encodeURIComponent(cycle_id)}`, {
+        token,
+        baseUrl: TRACK_API_URL,
+        method: 'DELETE',
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Cycle ${cycle_id} deleted.` }],
+      };
+    },
+  );
+}

--- a/packages/mcp-track/src/tools/issues.ts
+++ b/packages/mcp-track/src/tools/issues.ts
@@ -131,4 +131,22 @@ export function registerIssueTools(server: McpServer) {
       };
     },
   );
+
+  server.tool(
+    'list_issue_links',
+    'List GitHub PR ↔ FerrTrack issue links for one issue (created by the GitHub webhook on push).',
+    {
+      issue_ref: z.string().min(1).describe('Issue ref, e.g. "FT-12"'),
+    },
+    async ({ issue_ref }) => {
+      const token = await getToken();
+      const links = await apiRequest<unknown>(`/v1/issues/${encodeURIComponent(issue_ref)}/links`, {
+        token,
+        baseUrl: TRACK_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(links, null, 2) }],
+      };
+    },
+  );
 }

--- a/packages/mcp-track/src/tools/milestones.ts
+++ b/packages/mcp-track/src/tools/milestones.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { TRACK_API_URL } from '../api-base.js';
+
+interface Milestone {
+  id: string;
+  project_id: string;
+  name: string;
+  description: string | null;
+  due_at: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export function registerMilestoneTools(server: McpServer) {
+  server.tool(
+    'list_milestones',
+    'List milestones for a FerrTrack project.',
+    {
+      project_slug: z.string().min(1).describe('Project slug'),
+    },
+    async ({ project_slug }) => {
+      const token = await getToken();
+      const milestones = await apiRequest<Milestone[]>(
+        `/v1/projects/${encodeURIComponent(project_slug)}/milestones`,
+        { token, baseUrl: TRACK_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(milestones, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'create_milestone',
+    'Create a milestone on a project. Due date is optional.',
+    {
+      project_slug: z.string().min(1).describe('Project slug'),
+      name: z.string().min(1).max(100),
+      description: z.string().max(2000).optional(),
+      due_at: z.string().optional().describe('ISO date.'),
+    },
+    async ({ project_slug, name, description, due_at }) => {
+      const token = await getToken();
+      const milestone = await apiRequest<Milestone>(
+        `/v1/projects/${encodeURIComponent(project_slug)}/milestones`,
+        {
+          token,
+          baseUrl: TRACK_API_URL,
+          method: 'POST',
+          body: {
+            name,
+            description: description ?? null,
+            due_at: due_at ?? null,
+          },
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(milestone, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'update_milestone',
+    'Patch a milestone — rename, retitle description, shift due date, flip status.',
+    {
+      milestone_id: z.string().min(1).describe('Milestone id'),
+      name: z.string().min(1).max(100).optional(),
+      description: z.string().max(2000).nullable().optional(),
+      due_at: z.string().nullable().optional(),
+      status: z.enum(['open', 'completed', 'cancelled']).optional(),
+    },
+    async ({ milestone_id, ...patch }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const milestone = await apiRequest<Milestone>(
+        `/v1/milestones/${encodeURIComponent(milestone_id)}`,
+        { token, baseUrl: TRACK_API_URL, method: 'PATCH', body },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(milestone, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'delete_milestone',
+    'Delete a milestone. Issues that were on it become un-milestoned.',
+    {
+      milestone_id: z.string().min(1).describe('Milestone id'),
+    },
+    async ({ milestone_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(`/v1/milestones/${encodeURIComponent(milestone_id)}`, {
+        token,
+        baseUrl: TRACK_API_URL,
+        method: 'DELETE',
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Milestone ${milestone_id} deleted.` }],
+      };
+    },
+  );
+}

--- a/packages/mcp-track/src/tools/search.ts
+++ b/packages/mcp-track/src/tools/search.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+import { TRACK_API_URL } from '../api-base.js';
+
+interface SearchHit {
+  kind: 'issue' | 'project';
+  ref: string | null;
+  slug: string | null;
+  title: string;
+  snippet: string | null;
+  score: number;
+}
+
+interface TrackUser {
+  id: string;
+  email: string;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+export function registerSearchTools(server: McpServer) {
+  server.tool(
+    'search_track',
+    "Full-text + trigram search across FerrTrack issues and projects in the caller's org. Returns ranked hits.",
+    {
+      q: z.string().min(1).describe('Search query.'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('Max hits to return (default 25).'),
+    },
+    async ({ q, limit }) => {
+      const token = await getToken();
+      const params = new URLSearchParams({ q });
+      if (limit !== undefined) params.set('limit', String(limit));
+      const hits = await apiRequest<SearchHit[]>(`/v1/search?${params.toString()}`, {
+        token,
+        baseUrl: TRACK_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(hits, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'list_track_users',
+    "List FerrTrack users in the caller's org — useful for resolving an `assignee_id` before calling create_issue or update_issue.",
+    {},
+    async () => {
+      const token = await getToken();
+      const users = await apiRequest<TrackUser[]>('/v1/users', {
+        token,
+        baseUrl: TRACK_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(users, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp-vault/src/index.ts
+++ b/packages/mcp-vault/src/index.ts
@@ -4,6 +4,7 @@ import { registerVaultDetailsTool } from './tools/vault-details.js';
 import { registerSecretTools } from './tools/secrets.js';
 import { registerVaultAuditTools } from './tools/audit.js';
 import { registerVaultMutationTools } from './tools/vaults.js';
+import { registerSecretMutationTools } from './tools/secret-mutations.js';
 
 runMcp({
   name: 'ferrlabs-vault',
@@ -13,6 +14,7 @@ runMcp({
     registerSecretTools(server);
     registerVaultAuditTools(server);
     registerVaultMutationTools(server);
+    registerSecretMutationTools(server);
   },
 }).catch((err: unknown) => {
   console.error('ferrlabs-mcp-vault fatal:', err instanceof Error ? err.message : err);

--- a/packages/mcp-vault/src/tools/secret-mutations.ts
+++ b/packages/mcp-vault/src/tools/secret-mutations.ts
@@ -1,0 +1,140 @@
+import { z } from 'zod';
+import { apiRequest, getToken, type McpServer } from '@ferrlabs/mcp-core';
+
+interface SecretSummary {
+  id: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  rotated_at: string | null;
+}
+
+function vaultBase(org_slug: string, project_slug: string, vault_id: string): string {
+  return `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/vaults/${encodeURIComponent(vault_id)}`;
+}
+
+export function registerSecretMutationTools(server: McpServer) {
+  server.tool(
+    'create_secret',
+    'Create a new secret inside a vault. The value is encrypted server-side under the org KEK (envelope encryption) — it never lands in clear in the DB.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+      name: z
+        .string()
+        .min(1)
+        .max(200)
+        .regex(/^[A-Z][A-Z0-9_]*$/, 'name must be SCREAMING_SNAKE_CASE')
+        .describe('Secret name (e.g. STRIPE_API_KEY)'),
+      value: z.string().min(1).describe('Plaintext value — encrypted at rest by the server.'),
+      description: z.string().max(500).optional().describe('Optional human-readable note.'),
+    },
+    async ({ org_slug, project_slug, vault_id, name, value, description }) => {
+      const token = await getToken();
+      const secret = await apiRequest<SecretSummary>(
+        `${vaultBase(org_slug, project_slug, vault_id)}/secrets`,
+        {
+          token,
+          method: 'POST',
+          body: { name, value, description: description ?? null },
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(secret, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'update_secret',
+    'Update a secret. Pass `value` to rotate it in place (preserves name + id); pass `description` to retitle it. Either or both may be omitted; nothing is touched unless you pass it.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+      secret_id: z.string().min(1).describe('Secret id'),
+      value: z.string().min(1).optional().describe('New plaintext value.'),
+      description: z.string().max(500).nullable().optional(),
+    },
+    async ({ org_slug, project_slug, vault_id, secret_id, ...patch }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const secret = await apiRequest<SecretSummary>(
+        `${vaultBase(org_slug, project_slug, vault_id)}/secrets/${encodeURIComponent(secret_id)}`,
+        { token, method: 'PATCH', body },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(secret, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'delete_secret',
+    'Permanently delete a secret. Irreversible at the API level — recovery only via the soft-delete window on the FerrVault dashboard.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+      secret_id: z.string().min(1).describe('Secret id'),
+    },
+    async ({ org_slug, project_slug, vault_id, secret_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(
+        `${vaultBase(org_slug, project_slug, vault_id)}/secrets/${encodeURIComponent(secret_id)}`,
+        { token, method: 'DELETE' },
+      );
+      return {
+        content: [{ type: 'text' as const, text: `Secret ${secret_id} deleted.` }],
+      };
+    },
+  );
+
+  server.tool(
+    'rotate_secret',
+    'Rotate a secret in-place — fans the new value through any FerrVault K8s operator deployments that mount it via SecretRef, so consumers pick up the new value on next sync without an app restart.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+      secret_id: z.string().min(1).describe('Secret id'),
+      value: z.string().min(1).describe('New plaintext value (will replace the current).'),
+    },
+    async ({ org_slug, project_slug, vault_id, secret_id, value }) => {
+      const token = await getToken();
+      const secret = await apiRequest<SecretSummary>(
+        `${vaultBase(org_slug, project_slug, vault_id)}/secrets/${encodeURIComponent(secret_id)}/rotate`,
+        { token, method: 'POST', body: { value } },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(secret, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'archive_secret_request',
+    'Archive a "missing secret" request — marks it handled and removes it from the active list. Use after provisioning the secret (or deciding it should not be provisioned).',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+      request_id: z.string().min(1).describe('Secret-request id'),
+    },
+    async ({ org_slug, project_slug, vault_id, request_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(
+        `${vaultBase(org_slug, project_slug, vault_id)}/secret-requests/${encodeURIComponent(request_id)}/archive`,
+        { token, method: 'POST' },
+      );
+      return {
+        content: [{ type: 'text' as const, text: `Secret request ${request_id} archived.` }],
+      };
+    },
+  );
+}

--- a/packages/mcp-vault/src/tools/vaults.ts
+++ b/packages/mcp-vault/src/tools/vaults.ts
@@ -10,6 +10,10 @@ interface VaultSummary {
   updated_at: string;
 }
 
+function vaultBase(org_slug: string, project_slug: string, vault_id: string): string {
+  return `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/vaults/${encodeURIComponent(vault_id)}`;
+}
+
 export function registerVaultMutationTools(server: McpServer) {
   server.tool(
     'create_vault',
@@ -24,14 +28,57 @@ export function registerVaultMutationTools(server: McpServer) {
       const token = await getToken();
       const vault = await apiRequest<VaultSummary>(
         `/v1/orgs/${encodeURIComponent(org_slug)}/projects/${encodeURIComponent(project_slug)}/vaults`,
-        {
-          token,
-          method: 'POST',
-          body: { name, description: description ?? null },
-        },
+        { token, method: 'POST', body: { name, description: description ?? null } },
       );
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(vault, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'update_vault',
+    'Patch a vault — rename it or change its description. Only the fields you pass are touched.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+      name: z.string().min(1).max(100).optional(),
+      description: z.string().max(500).nullable().optional(),
+    },
+    async ({ org_slug, project_slug, vault_id, ...patch }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const vault = await apiRequest<VaultSummary>(vaultBase(org_slug, project_slug, vault_id), {
+        token,
+        method: 'PATCH',
+        body,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(vault, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'delete_vault',
+    'Delete a vault and ALL its secrets. Irreversible. The server enforces a soft-delete window; check the FerrVault UI to confirm.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      project_slug: z.string().min(1).describe('Project slug'),
+      vault_id: z.string().min(1).describe('Vault id'),
+    },
+    async ({ org_slug, project_slug, vault_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(vaultBase(org_slug, project_slug, vault_id), {
+        token,
+        method: 'DELETE',
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Vault ${vault_id} deleted.` }],
       };
     },
   );


### PR DESCRIPTION
Closes #149. Fills CRUD gaps across three sub-MCPs. Vault: update_vault, delete_vault, create_secret, update_secret, delete_secret, rotate_secret, archive_secret_request. Track: list_cycles, list_cycle_issues, create_cycle, plan_next_cycle, update_cycle, delete_cycle, list_milestones, create_milestone, update_milestone, delete_milestone, search_track, list_track_users, list_issue_links, update_issue_comment, delete_issue_comment. Growth: create_site, update_site, archive_site, attach_domain, verify_domain, detach_domain, create_page, update_page, discover_pages, import_pages, list_releases, activate_release, create_form, update_form, delete_form. Total +30 tools. Verification: pnpm typecheck clean, pnpm test 22/22 green. Fleet was intentionally not extended — its remaining endpoints are stubs or internal-only.