### PR TITLE
chore(ci): bump FerrLabs/FerrFlow action to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: FerrLabs/FerrFlow@v4
+      - uses: FerrLabs/FerrFlow@v5
         with:
           dry_run: ${{ inputs.dry_run }}
           bot: true


### PR DESCRIPTION
## Summary
- Bump `FerrLabs/FerrFlow@v4` → `@v5` in workflow files.

## Why
FerrFlow v5.0.0 released (2026-05-21). The only breaking change is internal — replaces URL token injection with the git credential helper protocol (#486 on FerrLabs/FerrFlow). The Action's YAML surface is unchanged; consumers just bump the major tag.

## Test plan
- [ ] CI green
- [ ] Next release run succeeds end-to-end