### PR TITLE
fix(http): emit RFC 6749 OAuth error body on 401 so mcp-remote can authenticate

### DIFF
--- a/packages/mcp-core/src/transports/__tests__/http.test.ts
+++ b/packages/mcp-core/src/transports/__tests__/http.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { unauthorizedChallenge } from '../http.js';
+
+describe('unauthorizedChallenge', () => {
+  const metadataUrl = 'https://mcp.ferrvault.com/.well-known/oauth-protected-resource';
+
+  it('returns an RFC 6749 §5.2 error body where `error` is a string', () => {
+    const { body } = unauthorizedChallenge(metadataUrl);
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    expect(typeof parsed.error).toBe('string');
+    expect(parsed.error).toBe('invalid_token');
+    expect(typeof parsed.error_description).toBe('string');
+  });
+
+  it('does not emit a JSON-RPC envelope that strict OAuth clients reject', () => {
+    const { body } = unauthorizedChallenge(metadataUrl);
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    expect(parsed.jsonrpc).toBeUndefined();
+    expect(typeof parsed.error).not.toBe('object');
+  });
+
+  it('builds a Bearer challenge carrying the error code and the resource metadata URL', () => {
+    const { wwwAuthenticate } = unauthorizedChallenge(metadataUrl);
+    expect(wwwAuthenticate.startsWith('Bearer ')).toBe(true);
+    expect(wwwAuthenticate).toContain('error="invalid_token"');
+    expect(wwwAuthenticate).toContain(`resource_metadata="${metadataUrl}"`);
+  });
+});

--- a/packages/mcp-core/src/transports/http.ts
+++ b/packages/mcp-core/src/transports/http.ts
@@ -22,6 +22,22 @@ function publicOrigin(req: IncomingMessage): string {
   return `${proto}://${host}`;
 }
 
+const UNAUTHORIZED_DESCRIPTION =
+  'Missing or invalid bearer token. Fetch the OAuth protected-resource metadata and run the authorization code + PKCE flow.';
+
+export function unauthorizedChallenge(metadataUrl: string): {
+  wwwAuthenticate: string;
+  body: string;
+} {
+  return {
+    wwwAuthenticate: `Bearer error="invalid_token", error_description="${UNAUTHORIZED_DESCRIPTION}", resource_metadata="${metadataUrl}"`,
+    body: JSON.stringify({
+      error: 'invalid_token',
+      error_description: UNAUTHORIZED_DESCRIPTION,
+    }),
+  };
+}
+
 export interface HttpServerOptions {
   port: number;
   host?: string;
@@ -69,22 +85,14 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
 
   function sendUnauthorized(req: IncomingMessage, res: ServerResponse): void {
     const origin = publicOrigin(req);
-    const metadataUrl = `${origin}/.well-known/oauth-protected-resource`;
+    const { wwwAuthenticate, body } = unauthorizedChallenge(
+      `${origin}/.well-known/oauth-protected-resource`,
+    );
     res.writeHead(401, {
       'Content-Type': 'application/json',
-      'WWW-Authenticate': `Bearer resource_metadata="${metadataUrl}"`,
+      'WWW-Authenticate': wwwAuthenticate,
     });
-    res.end(
-      JSON.stringify({
-        jsonrpc: '2.0',
-        error: {
-          code: -32001,
-          message:
-            'Missing or invalid bearer token. The MCP client should fetch the OAuth protected-resource metadata and run the authorization code + PKCE flow.',
-        },
-        id: null,
-      }),
-    );
+    res.end(body);
   }
 
   function sendResourceMetadata(req: IncomingMessage, res: ServerResponse): void {


### PR DESCRIPTION
Closes #163

## Summary
The shared HTTP transport returned its 401 as a JSON-RPC envelope (`error` = object). Strict OAuth clients like `mcp-remote` (Claude Desktop) reject that and exit, so the FerrLabs MCP servers never connect on Desktop.

## Changes
- `sendUnauthorized` now returns `{"error":"invalid_token","error_description":...}` (RFC 6749 §5.2 / RFC 6750) and puts `error="invalid_token"` in the `WWW-Authenticate` header.
- Extracted a pure `unauthorizedChallenge()` helper.

## Testing
- New unit tests assert the body has `error` as a string, no JSON-RPC envelope, and a well-formed Bearer challenge. `typecheck` + `vitest` green.

## Deploy note
Takes effect once mcp-core is released and the product MCP servers bump the dependency and redeploy.