### PR TITLE
feat(mcp): admin tools — org/members/teams/billing/sessions/profile

### DIFF
--- a/packages/mcp-growth/src/tools/forms.ts
+++ b/packages/mcp-growth/src/tools/forms.ts
@@ -22,6 +22,25 @@ interface FormSubmission {
 
 export function registerFormTools(server: McpServer) {
   server.tool(
+    'get_form',
+    'Get the schema of a single FerrGrowth form (fields, validation, name).',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      form_id: z.string().min(1).describe('Form id'),
+    },
+    async ({ site_id, form_id }) => {
+      const token = await getToken();
+      const form = await apiRequest<Form>(
+        `/v1/sites/${encodeURIComponent(site_id)}/forms/${encodeURIComponent(form_id)}`,
+        { token, baseUrl: GROWTH_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(form, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
     'list_forms',
     'List forms attached to a FerrGrowth site.',
     {

--- a/packages/mcp-growth/src/tools/releases.ts
+++ b/packages/mcp-growth/src/tools/releases.ts
@@ -13,6 +13,25 @@ interface Release {
 
 export function registerReleaseTools(server: McpServer) {
   server.tool(
+    'get_release',
+    'Get details of a single FerrGrowth release (build metadata, size, active flag).',
+    {
+      site_id: z.string().min(1).describe('Site id or slug'),
+      release_id: z.string().min(1).describe('Release id'),
+    },
+    async ({ site_id, release_id }) => {
+      const token = await getToken();
+      const release = await apiRequest<Release>(
+        `/v1/sites/${encodeURIComponent(site_id)}/releases/${encodeURIComponent(release_id)}`,
+        { token, baseUrl: GROWTH_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(release, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
     'list_releases',
     'List bundle releases of a FerrGrowth site (built artefacts). The one with `active: true` is the one currently served.',
     {

--- a/packages/mcp-track/src/tools/cycles.ts
+++ b/packages/mcp-track/src/tools/cycles.ts
@@ -24,6 +24,24 @@ interface CycleIssue {
 
 export function registerCycleTools(server: McpServer) {
   server.tool(
+    'get_cycle',
+    'Get a single FerrTrack cycle by id.',
+    {
+      cycle_id: z.string().min(1).describe('Cycle id'),
+    },
+    async ({ cycle_id }) => {
+      const token = await getToken();
+      const cycle = await apiRequest<Cycle>(`/v1/cycles/${encodeURIComponent(cycle_id)}`, {
+        token,
+        baseUrl: TRACK_API_URL,
+      });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(cycle, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
     'list_cycles',
     'List cycles (sprints) for a FerrTrack project.',
     {

--- a/packages/mcp-track/src/tools/milestones.ts
+++ b/packages/mcp-track/src/tools/milestones.ts
@@ -15,6 +15,24 @@ interface Milestone {
 
 export function registerMilestoneTools(server: McpServer) {
   server.tool(
+    'get_milestone',
+    'Get a single FerrTrack milestone by id.',
+    {
+      milestone_id: z.string().min(1).describe('Milestone id'),
+    },
+    async ({ milestone_id }) => {
+      const token = await getToken();
+      const milestone = await apiRequest<Milestone>(
+        `/v1/milestones/${encodeURIComponent(milestone_id)}`,
+        { token, baseUrl: TRACK_API_URL },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(milestone, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
     'list_milestones',
     'List milestones for a FerrTrack project.',
     {

--- a/packages/mcp-track/src/tools/projects.ts
+++ b/packages/mcp-track/src/tools/projects.ts
@@ -78,4 +78,28 @@ export function registerProjectTools(server: McpServer) {
       };
     },
   );
+
+  server.tool(
+    'update_project',
+    'Patch a FerrTrack project — rename it or update its summary. Slug and prefix are immutable to keep issue refs stable.',
+    {
+      project_slug: z.string().min(1).describe('Project slug'),
+      name: z.string().min(1).max(100).optional(),
+      summary: z.string().max(500).nullable().optional(),
+    },
+    async ({ project_slug, ...patch }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const project = await apiRequest<Project>(
+        `/v1/projects/${encodeURIComponent(project_slug)}`,
+        { token, baseUrl: TRACK_API_URL, method: 'PATCH', body },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(project, null, 2) }],
+      };
+    },
+  );
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,6 +3,8 @@ import { runMcp } from '@ferrlabs/mcp-core';
 import { registerStatsTools } from './tools/stats.js';
 import { registerTokenTools } from './tools/tokens.js';
 import { registerOrgsTools } from './tools/orgs.js';
+import { registerOrgAdminTools } from './tools/org-admin.js';
+import { registerMeTools } from './tools/me.js';
 import { registerVaultsTools } from './tools/vaults.js';
 import { registerIssuesTools } from './tools/issues.js';
 import { registerSubscriptionsTools } from './tools/subscriptions.js';
@@ -15,6 +17,8 @@ runMcp({
     registerStatsTools(server);
     registerTokenTools(server);
     registerOrgsTools(server);
+    registerOrgAdminTools(server);
+    registerMeTools(server);
     registerVaultsTools(server);
     registerIssuesTools(server);
     registerSubscriptionsTools(server);

--- a/packages/mcp/src/tools/me.ts
+++ b/packages/mcp/src/tools/me.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { apiRequest, getToken } from '@ferrlabs/mcp-core';
+
+interface MeProfile {
+  id: string;
+  email: string;
+  email_verified: boolean;
+  display_name: string | null;
+  avatar_url: string | null;
+  timezone: string;
+  locale: string;
+  preferences: Record<string, unknown>;
+  is_staff: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MeSession {
+  id: string;
+  client_id: string;
+  user_agent: string | null;
+  ip: string | null;
+  last_active_at: string;
+  expires_at: string;
+  created_at: string;
+  current: boolean;
+}
+
+export function registerMeTools(server: McpServer) {
+  server.tool(
+    'update_me',
+    "Patch the authenticated user's own profile — display name, timezone, locale, avatar URL. Email + password rotate via dedicated flows in the UI, not here.",
+    {
+      display_name: z.string().min(1).max(100).optional(),
+      timezone: z.string().min(1).max(64).optional().describe("IANA tz, e.g. 'Europe/Paris'."),
+      locale: z
+        .string()
+        .regex(/^[a-z]{2}(-[A-Z]{2})?$/)
+        .optional()
+        .describe("BCP 47, e.g. 'en' or 'fr-FR'."),
+      avatar_url: z.string().url().nullable().optional(),
+    },
+    async (patch) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const me = await apiRequest<MeProfile>('/v1/auth/me', {
+        token,
+        method: 'PATCH',
+        body,
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(me, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'list_my_sessions',
+    'List your active sessions across devices/browsers. The session you used to obtain the current token is flagged `current: true`.',
+    {},
+    async () => {
+      const token = await getToken();
+      const sessions = await apiRequest<MeSession[]>('/v1/me/sessions', { token });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(sessions, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'revoke_my_session',
+    'Revoke one of your active sessions by id (sign out that device). Refusing to revoke the current session is left up to the API.',
+    {
+      session_id: z.string().min(1).describe('Session id (from list_my_sessions)'),
+    },
+    async ({ session_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(`/v1/me/sessions/${encodeURIComponent(session_id)}`, {
+        token,
+        method: 'DELETE',
+      });
+      return { content: [{ type: 'text' as const, text: `Session ${session_id} revoked.` }] };
+    },
+  );
+
+  server.tool(
+    'export_my_account',
+    "Trigger an export of the authenticated user's data (GDPR Article 15). Returns the export bundle, which can be large; consider redirecting the LLM context to a summary.",
+    {},
+    async () => {
+      const token = await getToken();
+      const dump = await apiRequest<unknown>('/v1/auth/me/export', { token });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(dump, null, 2) }] };
+    },
+  );
+}

--- a/packages/mcp/src/tools/org-admin.ts
+++ b/packages/mcp/src/tools/org-admin.ts
@@ -1,0 +1,345 @@
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { apiRequest, getToken } from '@ferrlabs/mcp-core';
+
+interface Org {
+  id: string;
+  slug: string;
+  name: string;
+  plan: string;
+  member_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface OrgOverview {
+  org: Org;
+  member_count: number;
+  active_subscriptions: Array<{ product: string; tier: string; status: string }>;
+  pending_invites: number;
+  recent_activity_count: number;
+}
+
+interface OrgUsage {
+  org_slug: string;
+  period: { from: string; to: string };
+  per_product: Array<{
+    product: string;
+    metric: string;
+    used: number;
+    limit: number | null;
+  }>;
+}
+
+interface OrgMember {
+  user_id: string;
+  email: string;
+  display_name: string | null;
+  role: 'owner' | 'admin' | 'member' | 'viewer';
+  joined_at: string;
+}
+
+interface AuditEntry {
+  id: string;
+  actor_id: string;
+  action: string;
+  target: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+interface Team {
+  id: string;
+  org_id: string;
+  name: string;
+  description: string | null;
+  member_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function orgBase(slug: string): string {
+  return `/v1/orgs/${encodeURIComponent(slug)}`;
+}
+
+export function registerOrgAdminTools(server: McpServer) {
+  server.tool(
+    'get_org',
+    'Get a single FerrLabs organization by slug.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+    },
+    async ({ org_slug }) => {
+      const token = await getToken();
+      const org = await apiRequest<Org>(orgBase(org_slug), { token });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(org, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'update_org',
+    'Patch an organization — rename it or change its slug. Slug changes propagate everywhere; double-check before doing it on a live org.',
+    {
+      org_slug: z.string().min(1).describe('Current organization slug'),
+      name: z.string().min(1).max(100).optional(),
+      new_slug: z
+        .string()
+        .min(2)
+        .max(40)
+        .regex(/^[a-z0-9-]+$/)
+        .optional()
+        .describe('New slug (lowercase alphanumeric + hyphens).'),
+    },
+    async ({ org_slug, name, new_slug }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      if (name !== undefined) body.name = name;
+      if (new_slug !== undefined) body.slug = new_slug;
+      const org = await apiRequest<Org>(orgBase(org_slug), {
+        token,
+        method: 'PATCH',
+        body,
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(org, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_org_overview',
+    'High-level dashboard view of an organization — member count, active subscriptions per product, pending invites, recent activity volume.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+    },
+    async ({ org_slug }) => {
+      const token = await getToken();
+      const overview = await apiRequest<OrgOverview>(`${orgBase(org_slug)}/overview`, { token });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(overview, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_org_usage',
+    'Current-period metered usage across all products for an org (FerrGrowth visits/bandwidth, FerrFleet runs, etc.) with limits per tier.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+    },
+    async ({ org_slug }) => {
+      const token = await getToken();
+      const usage = await apiRequest<OrgUsage>(`${orgBase(org_slug)}/usage`, { token });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(usage, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'list_org_audit',
+    'Recent audit log for an organization — member changes, subscription updates, sensitive admin actions.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(200)
+        .optional()
+        .describe('Max entries to return (default 50).'),
+    },
+    async ({ org_slug, limit }) => {
+      const token = await getToken();
+      const qs = limit !== undefined ? `?limit=${limit}` : '';
+      const entries = await apiRequest<AuditEntry[]>(`${orgBase(org_slug)}/audit${qs}`, { token });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(entries, null, 2) }] };
+    },
+  );
+
+  // --------------------------------------------------------------------------
+  // Members
+  // --------------------------------------------------------------------------
+
+  server.tool(
+    'list_org_members',
+    'Members of an organization with their roles. Useful to look up a user_id before assigning issues or granting team membership.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+    },
+    async ({ org_slug }) => {
+      const token = await getToken();
+      const members = await apiRequest<OrgMember[]>(`${orgBase(org_slug)}/members`, { token });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(members, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'invite_org_member',
+    'Invite a user (by email) to join an organization with a specific role. The user receives an invitation email; they appear in list_org_members once they accept.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      email: z.string().email().describe('Invitee email address'),
+      role: z
+        .enum(['admin', 'member', 'viewer'])
+        .default('member')
+        .describe(
+          'Org-level role (default member). Owners can only be promoted from existing admins.',
+        ),
+    },
+    async ({ org_slug, email, role }) => {
+      const token = await getToken();
+      const member = await apiRequest<OrgMember>(`${orgBase(org_slug)}/members`, {
+        token,
+        method: 'POST',
+        body: { email, role },
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(member, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'update_org_member_role',
+    "Change a member's role inside an organization. Promoting to owner requires the caller to be an owner.",
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      user_id: z.string().min(1).describe('User id of the member to update'),
+      role: z.enum(['owner', 'admin', 'member', 'viewer']),
+    },
+    async ({ org_slug, user_id, role }) => {
+      const token = await getToken();
+      const member = await apiRequest<OrgMember>(
+        `${orgBase(org_slug)}/members/${encodeURIComponent(user_id)}`,
+        { token, method: 'PATCH', body: { role } },
+      );
+      return { content: [{ type: 'text' as const, text: JSON.stringify(member, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'remove_org_member',
+    'Remove a user from an organization. Irreversible; the user can be re-invited.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      user_id: z.string().min(1).describe('User id of the member to remove'),
+    },
+    async ({ org_slug, user_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(`${orgBase(org_slug)}/members/${encodeURIComponent(user_id)}`, {
+        token,
+        method: 'DELETE',
+      });
+      return {
+        content: [{ type: 'text' as const, text: `User ${user_id} removed from ${org_slug}.` }],
+      };
+    },
+  );
+
+  // --------------------------------------------------------------------------
+  // Teams
+  // --------------------------------------------------------------------------
+
+  server.tool(
+    'list_teams',
+    'List teams (sub-groups) inside an organization. Teams are used for fine-grained permissions and assignee groups.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+    },
+    async ({ org_slug }) => {
+      const token = await getToken();
+      const teams = await apiRequest<Team[]>(`${orgBase(org_slug)}/teams`, { token });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(teams, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'create_team',
+    'Create a new team inside an organization. Teams start empty — add members with add_team_member.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      name: z.string().min(1).max(100),
+      description: z.string().max(500).optional(),
+    },
+    async ({ org_slug, name, description }) => {
+      const token = await getToken();
+      const team = await apiRequest<Team>(`${orgBase(org_slug)}/teams`, {
+        token,
+        method: 'POST',
+        body: { name, description: description ?? null },
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(team, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'update_team',
+    'Patch a team — rename or change description.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      team_id: z.string().min(1).describe('Team id'),
+      name: z.string().min(1).max(100).optional(),
+      description: z.string().max(500).nullable().optional(),
+    },
+    async ({ org_slug, team_id, ...patch }) => {
+      const token = await getToken();
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(patch)) {
+        if (v !== undefined) body[k] = v;
+      }
+      const team = await apiRequest<Team>(
+        `${orgBase(org_slug)}/teams/${encodeURIComponent(team_id)}`,
+        { token, method: 'PATCH', body },
+      );
+      return { content: [{ type: 'text' as const, text: JSON.stringify(team, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'delete_team',
+    'Delete a team. Members of the team are NOT removed from the org; they just lose team-scoped permissions.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      team_id: z.string().min(1).describe('Team id'),
+    },
+    async ({ org_slug, team_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(`${orgBase(org_slug)}/teams/${encodeURIComponent(team_id)}`, {
+        token,
+        method: 'DELETE',
+      });
+      return { content: [{ type: 'text' as const, text: `Team ${team_id} deleted.` }] };
+    },
+  );
+
+  server.tool(
+    'add_team_member',
+    'Add a user (already an org member) to a team.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      team_id: z.string().min(1).describe('Team id'),
+      user_id: z.string().min(1).describe('User id to add'),
+    },
+    async ({ org_slug, team_id, user_id }) => {
+      const token = await getToken();
+      const result = await apiRequest<unknown>(
+        `${orgBase(org_slug)}/teams/${encodeURIComponent(team_id)}/members`,
+        { token, method: 'POST', body: { user_id } },
+      );
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'remove_team_member',
+    'Remove a user from a team. The user remains an org member.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      team_id: z.string().min(1).describe('Team id'),
+      user_id: z.string().min(1).describe('User id to remove'),
+    },
+    async ({ org_slug, team_id, user_id }) => {
+      const token = await getToken();
+      await apiRequest<void>(
+        `${orgBase(org_slug)}/teams/${encodeURIComponent(team_id)}/members/${encodeURIComponent(user_id)}`,
+        { token, method: 'DELETE' },
+      );
+      return {
+        content: [{ type: 'text' as const, text: `User ${user_id} removed from team ${team_id}.` }],
+      };
+    },
+  );
+}

--- a/packages/mcp/src/tools/subscriptions.ts
+++ b/packages/mcp/src/tools/subscriptions.ts
@@ -33,4 +33,74 @@ export function registerSubscriptionsTools(server: McpServer) {
       };
     },
   );
+
+  const PRODUCTS = ['ferrvault', 'ferrtrack', 'ferrgrowth', 'ferrfleet', 'ferrlens'] as const;
+  const TIERS = ['free', 'pro', 'team', 'enterprise'] as const;
+
+  server.tool(
+    'activate_subscription',
+    'Activate a product subscription on an organization. Starts the trial clock when applicable. Caller must be an org owner/admin; the API enforces billing-info presence for paid tiers.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      product: z.enum(PRODUCTS),
+      tier: z.enum(TIERS).default('free').describe('Tier (default free).'),
+    },
+    async ({ org_slug, product, tier }) => {
+      const token = await getToken();
+      const sub = await apiRequest<SubscriptionRow>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/subscriptions`,
+        { token, method: 'POST', body: { product, tier } },
+      );
+      return { content: [{ type: 'text' as const, text: JSON.stringify(sub, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'update_subscription',
+    'Change the tier of an active product subscription (upgrade/downgrade). Stripe proration is applied per the API config.',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      product: z.enum(PRODUCTS),
+      tier: z.enum(TIERS),
+    },
+    async ({ org_slug, product, tier }) => {
+      const token = await getToken();
+      const sub = await apiRequest<SubscriptionRow>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/subscriptions/${encodeURIComponent(product)}`,
+        { token, method: 'PATCH', body: { tier } },
+      );
+      return { content: [{ type: 'text' as const, text: JSON.stringify(sub, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'cancel_subscription',
+    'Cancel a product subscription on an organization. By default the cancellation takes effect at the end of the current billing period; pass immediate=true to cut it off now (with proration).',
+    {
+      org_slug: z.string().min(1).describe('Organization slug'),
+      product: z.enum(PRODUCTS),
+      immediate: z
+        .boolean()
+        .optional()
+        .describe(
+          'Cut off immediately and refund prorated amount. Default false (cancel at period end).',
+        ),
+    },
+    async ({ org_slug, product, immediate }) => {
+      const token = await getToken();
+      const qs = immediate ? '?immediate=true' : '';
+      await apiRequest<void>(
+        `/v1/orgs/${encodeURIComponent(org_slug)}/subscriptions/${encodeURIComponent(product)}${qs}`,
+        { token, method: 'DELETE' },
+      );
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Subscription ${product} on ${org_slug} ${immediate ? 'cancelled immediately' : 'set to cancel at period end'}.`,
+          },
+        ],
+      };
+    },
+  );
 }


### PR DESCRIPTION
Adds the biggest gap left in the core ferrlabs MCP: admin / billing / profile operations. +25 tools total. Core: get_org, update_org, get_org_overview, get_org_usage, list_org_audit, list_org_members, invite_org_member, update_org_member_role, remove_org_member, list_teams, create_team, update_team, delete_team, add_team_member, remove_team_member, update_me, list_my_sessions, revoke_my_session, export_my_account, activate_subscription, update_subscription, cancel_subscription. Track: update_project, get_cycle, get_milestone. Growth: get_form, get_release. Typecheck clean, 27/27 tests green.