### PR TITLE
ci: drop redundant runner override (reusables auto-select)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
     uses: FerrLabs/.github/.github/workflows/reusable-ci-node.yml@main
     with:
       enable-sonar: true
-      runner: ubuntu-latest
       install-args: ''
       enable-lint: false
       enable-knip: false


### PR DESCRIPTION
Drops the now-redundant `runner:` overrides on the auto-selecting reusables. Since FerrLabs/.github#82, an empty `runner` auto-picks ferrlabs-k8s(-large) for private repos and ubuntu-latest for public ones. `reusable-docker-build` calls are left untouched. Part of FerrLabs/.github#82.