### PR TITLE
ci: use the reusable FerrFlow release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,11 @@ jobs:
   release:
     name: Release
     needs: test
-    runs-on: ubuntu-latest
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.test.result == 'success') || (github.event_name == 'workflow_dispatch' && needs.test.result == 'success')
     permissions:
       contents: write
       id-token: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: FerrLabs/FerrFlow@v5
-        with:
-          dry_run: ${{ inputs.dry_run }}
-          bot: true
+    uses: FerrLabs/.github/.github/workflows/reusable-ferrflow-release.yml@main
+    with:
+      dry-run: ${{ inputs.dry_run || false }}
+    secrets: inherit


### PR DESCRIPTION
The `release` job in `ci.yml` now calls `reusable-ferrflow-release.yml` (same `needs`/`if`, job-level `permissions`). Runner auto-selects by visibility.\n\nCloses 170