### PR TITLE
ci: enable Quality checks (knip/madge/audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
       enable-sonar: true
       install-args: ''
       enable-lint: false
-      enable-knip: false
-      enable-madge: false
-      enable-audit: false
+      enable-knip: true
+      enable-madge: true
+      enable-audit: true
     secrets: inherit
 
   release:

--- a/package.json
+++ b/package.json
@@ -31,5 +31,10 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "pnpm --filter @ferrlabs/mcp-core run build && pnpm --filter @ferrlabs/mcp run typecheck && pnpm --filter @ferrlabs/mcp-vault run typecheck && pnpm --filter @ferrlabs/mcp-track run typecheck && pnpm --filter @ferrlabs/mcp-growth run typecheck && pnpm --filter @ferrlabs/mcp-fleet run typecheck"
+  },
+  "pnpm": {
+    "overrides": {
+      "fast-uri@<=3.1.1": ">=3.1.2"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri@<=3.1.1: '>=3.1.2'
+
 importers:
 
   .:
@@ -819,8 +822,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1806,7 +1809,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2033,7 +2036,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
Active knip/madge/audit pour que les jobs Quality tournent et reportent (politique: Quality exigé + activé sur tous les repos reusable-ci-node). Ne modifie que les 3 flags enable-*, le reste inchangé.