### PR TITLE
ci: make madge real (point madge-paths at actual source)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       enable-lint: false
       enable-knip: true
       enable-madge: true
+      madge-paths: packages/*/src
       enable-audit: true
     secrets: inherit
 


### PR DESCRIPTION
madge tournait à vide: il scannait `./src` (inexistant dans ces monorepos) et passait sans rien analyser. Pointe `madge-paths` sur les vrais dossiers source pour que la détection de cycles soit **réelle**. Vérifié localement: **0 cycle** dans tous les packages → passe au vert.