### PR TITLE
fix(server): read MCP server version from package.json at runtime

### DIFF
--- a/packages/mcp-core/src/__tests__/version.test.ts
+++ b/packages/mcp-core/src/__tests__/version.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { readPackageVersion } from '../version.js';
+
+describe('readPackageVersion', () => {
+  it('reads the version from the parent-directory package.json of an entry module', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-version-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ version: '9.9.9' }), 'utf8');
+    const entryUrl = pathToFileURL(join(dir, 'dist', 'index.js')).href;
+
+    expect(readPackageVersion(entryUrl)).toBe('9.9.9');
+  });
+
+  it('throws when the package.json has no version field', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-version-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x' }), 'utf8');
+    const entryUrl = pathToFileURL(join(dir, 'dist', 'index.js')).href;
+
+    expect(() => readPackageVersion(entryUrl)).toThrow(/no version field/);
+  });
+});

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -2,4 +2,5 @@ export { runMcp, type RunMcpOptions } from './runner.js';
 export { apiRequest, UnauthorizedError } from './api-client.js';
 export { getToken, clearTokenCache } from './auth/index.js';
 export { runWithAuthContext, getRequestBearerToken } from './auth/context.js';
+export { readPackageVersion } from './version.js';
 export type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';

--- a/packages/mcp-core/src/version.ts
+++ b/packages/mcp-core/src/version.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export function readPackageVersion(entryUrl: string): string {
+  const packageJsonUrl = new URL('../package.json', entryUrl);
+  const raw = readFileSync(fileURLToPath(packageJsonUrl), 'utf8');
+  const parsed = JSON.parse(raw) as { version?: unknown };
+  if (typeof parsed.version !== 'string' || parsed.version.length === 0) {
+    throw new Error(`package.json at ${packageJsonUrl.href} has no version field`);
+  }
+  return parsed.version;
+}

--- a/packages/mcp-fleet/src/index.ts
+++ b/packages/mcp-fleet/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-import { runMcp } from '@ferrlabs/mcp-core';
+import { runMcp, readPackageVersion } from '@ferrlabs/mcp-core';
 import { registerAgentTools } from './tools/agents.js';
 import { registerRunTools } from './tools/runs.js';
 
 runMcp({
   name: 'ferrlabs-fleet',
-  version: '6.0.0',
+  version: readPackageVersion(import.meta.url),
   register: (server) => {
     registerAgentTools(server);
     registerRunTools(server);

--- a/packages/mcp-growth/src/index.ts
+++ b/packages/mcp-growth/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { runMcp } from '@ferrlabs/mcp-core';
+import { runMcp, readPackageVersion } from '@ferrlabs/mcp-core';
 import { registerSiteTools } from './tools/sites.js';
 import { registerPageTools } from './tools/pages.js';
 import { registerFormTools } from './tools/forms.js';
@@ -9,7 +9,7 @@ import { registerReleaseTools } from './tools/releases.js';
 
 runMcp({
   name: 'ferrlabs-growth',
-  version: '6.0.0',
+  version: readPackageVersion(import.meta.url),
   register: (server) => {
     registerSiteTools(server);
     registerPageTools(server);

--- a/packages/mcp-track/src/index.ts
+++ b/packages/mcp-track/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { runMcp } from '@ferrlabs/mcp-core';
+import { runMcp, readPackageVersion } from '@ferrlabs/mcp-core';
 import { registerIssueDetailsTool } from './tools/issue-details.js';
 import { registerIssueTools } from './tools/issues.js';
 import { registerCommentTools } from './tools/comments.js';
@@ -10,7 +10,7 @@ import { registerSearchTools } from './tools/search.js';
 
 runMcp({
   name: 'ferrlabs-track',
-  version: '6.0.0',
+  version: readPackageVersion(import.meta.url),
   register: (server) => {
     registerProjectTools(server);
     registerIssueDetailsTool(server);

--- a/packages/mcp-vault/src/index.ts
+++ b/packages/mcp-vault/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { runMcp } from '@ferrlabs/mcp-core';
+import { runMcp, readPackageVersion } from '@ferrlabs/mcp-core';
 import { registerVaultDetailsTool } from './tools/vault-details.js';
 import { registerSecretTools } from './tools/secrets.js';
 import { registerVaultAuditTools } from './tools/audit.js';
@@ -8,7 +8,7 @@ import { registerSecretMutationTools } from './tools/secret-mutations.js';
 
 runMcp({
   name: 'ferrlabs-vault',
-  version: '5.2.5',
+  version: readPackageVersion(import.meta.url),
   register: (server) => {
     registerVaultDetailsTool(server);
     registerSecretTools(server);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { runMcp } from '@ferrlabs/mcp-core';
+import { runMcp, readPackageVersion } from '@ferrlabs/mcp-core';
 import { registerStatsTools } from './tools/stats.js';
 import { registerTokenTools } from './tools/tokens.js';
 import { registerOrgsTools } from './tools/orgs.js';
@@ -12,7 +12,7 @@ import { registerDocsTools } from './tools/docs.js';
 
 runMcp({
   name: 'ferrlabs',
-  version: '5.2.5',
+  version: readPackageVersion(import.meta.url),
   register: (server) => {
     registerStatsTools(server);
     registerTokenTools(server);


### PR DESCRIPTION
The version reported to MCP clients via `new McpServer(...)` was a hardcoded literal in each entrypoint (`5.2.5` / `6.0.0`), while the published packages are at 6.5.0. FerrFlow only bumps the `package.json` `versionedFiles`, so these literals drift on every release.

Adds `readPackageVersion(import.meta.url)` in `@ferrlabs/mcp-core` and uses it in all five entrypoints (mcp, vault, fleet, growth, track) so the advertised version always matches the package.

Closes #79
Refs #177 (medium: serverInfo version hardcoded)

Built and tested locally: `pnpm build` + `pnpm test` green (29 tests). New unit test in `packages/mcp-core/src/__tests__/version.test.ts` covers the resolve and the missing-version error path; verified the built dist reports 6.5.0 at runtime.