### PR TITLE
fix(docs): remove committed SonarQube badge token from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FerrLabs MCP Server
 
 [![npm](https://img.shields.io/npm/v/@ferrlabs/mcp)](https://www.npmjs.com/package/@ferrlabs/mcp)
-[![Quality Gate](https://sonar.ferrlabs.com/api/project_badges/measure?project=MCP&metric=alert_status&token=sqb_df3c6923234b4dc9cc88fdd1b251c8a54c3b7903)](https://sonar.ferrlabs.com/dashboard?id=MCP)
-[![Coverage](https://sonar.ferrlabs.com/api/project_badges/measure?project=MCP&metric=coverage&token=sqb_df3c6923234b4dc9cc88fdd1b251c8a54c3b7903)](https://sonar.ferrlabs.com/dashboard?id=MCP)
+[![Quality Gate](https://sonar.ferrlabs.com/api/project_badges/measure?project=MCP&metric=alert_status)](https://sonar.ferrlabs.com/dashboard?id=MCP)
+[![Coverage](https://sonar.ferrlabs.com/api/project_badges/measure?project=MCP&metric=coverage)](https://sonar.ferrlabs.com/dashboard?id=MCP)
 [![License](https://img.shields.io/github/license/FerrLabs/MCP)](LICENSE)
 
 [Model Context Protocol](https://modelcontextprotocol.io) server that lets AI assistants interact with the FerrLabs ecosystem (FerrFlow, FerrVault, FerrTrack, FerrGrowth, FerrFleet, FerrLens) through the unified FerrLabs API. Runs locally via stdio transport.


### PR DESCRIPTION
The README embedded a live SonarQube project-badge token (`token=sqb_...`) directly in the Quality Gate and Coverage badge URLs (added in 8d5644f). That is a checked-in credential in a public, npm-published repo. SonarQube serves project badges without the token when the project's badge access is public, so the token param is dropped here.

This removes the secret from the current tree only. Two follow-up actions still require a human and are out of scope for this PR:
- Rotate the `sqb_df3c...` token in SonarQube (it remains valid until rotated).
- Scrub it from git history (it stays in commit 8d5644f's diff even after this edit).

Refs #173, #177 (medium: live SonarQube token committed in README badges).