### PR TITLE
fix(auth): write persisted token atomically with 0600 permissions

### DIFF
--- a/packages/mcp-core/src/auth/__tests__/persistence.test.ts
+++ b/packages/mcp-core/src/auth/__tests__/persistence.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir, platform } from 'node:os';
+import { join } from 'node:path';
+
+const isPosix = platform() !== 'win32';
+
+describe('writePersistedToken', () => {
+  const originalEnv = process.env;
+  let dir: string;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.FERRLABS_MCP_NO_PERSIST;
+    dir = mkdtempSync(join(tmpdir(), 'mcp-persist-'));
+    process.env.FERRLABS_MCP_TOKEN_PATH = join(dir, 'nested', 'token.json');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips the persisted token', async () => {
+    const { writePersistedToken, readPersistedToken } = await import('../persistence.js');
+    await writePersistedToken('fl_secret', ['read']);
+    expect(await readPersistedToken()).toBe('fl_secret');
+  });
+
+  it.runIf(isPosix)('writes the token file with mode no broader than 0600', async () => {
+    const { writePersistedToken } = await import('../persistence.js');
+    const path = process.env.FERRLABS_MCP_TOKEN_PATH as string;
+    await writePersistedToken('fl_secret');
+    const mode = statSync(path).mode & 0o777;
+    expect(mode & 0o177).toBe(0);
+    expect(mode).toBe(0o600);
+  });
+
+  it.runIf(isPosix)('creates the parent directory with mode 0700', async () => {
+    const { writePersistedToken } = await import('../persistence.js');
+    const path = process.env.FERRLABS_MCP_TOKEN_PATH as string;
+    await writePersistedToken('fl_secret');
+    const dirMode = statSync(join(path, '..')).mode & 0o777;
+    expect(dirMode & 0o077).toBe(0);
+  });
+});

--- a/packages/mcp-core/src/auth/persistence.ts
+++ b/packages/mcp-core/src/auth/persistence.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile, chmod } from 'node:fs/promises';
+import { mkdir, readFile, writeFile, chmod, rename, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { homedir, platform } from 'node:os';
 
@@ -50,24 +50,27 @@ export async function readPersistedToken(): Promise<string | null> {
 export async function writePersistedToken(token: string, scopes?: string[]): Promise<void> {
   if (process.env.FERRLABS_MCP_NO_PERSIST === '1') return;
   const path = defaultTokenPath();
-  await mkdir(dirname(path), { recursive: true });
+  const isPosix = platform() !== 'win32';
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
   const payload: PersistedToken = {
     token,
     obtained_at: new Date().toISOString(),
     scopes,
   };
-  await writeFile(path, JSON.stringify(payload, null, 2), 'utf8');
-  if (platform() !== 'win32') {
-    try {
-      await chmod(path, 0o600);
-    } catch {
-      // ignore — best effort on platforms that don't support POSIX modes
+  const tmpPath = `${path}.${process.pid}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(payload, null, 2), { encoding: 'utf8', mode: 0o600 });
+  try {
+    if (isPosix) {
+      await chmod(tmpPath, 0o600);
     }
+    await rename(tmpPath, path);
+  } catch (err) {
+    await unlink(tmpPath).catch(() => undefined);
+    throw err;
   }
 }
 
 export async function clearPersistedToken(): Promise<void> {
-  const { unlink } = await import('node:fs/promises');
   try {
     await unlink(defaultTokenPath());
   } catch {


### PR DESCRIPTION
`writePersistedToken` wrote the long-lived `fl_...` session token with `writeFile(...)` (default umask, typically 0644) and only narrowed permissions afterward with a best-effort `chmod` whose failure was silently swallowed. That left a TOCTOU window where the plaintext token was world-readable, and a permanent 0644 file if `chmod` threw.

Now the token is written to a `${path}.${pid}.tmp` sibling created with `mode: 0o600`, `chmod`-ed to 0600 on POSIX, then atomically `rename`-d into place; the temp file is cleaned up and the error propagated on failure instead of being swallowed. The parent directory is created with `mode: 0o700`. Also removed the redundant dynamic `import('node:fs/promises')` in `clearPersistedToken` now that `unlink` is imported at the top.

Tests in `persistence.test.ts` assert the round-trip plus (POSIX-only) that the file mode is exactly 0600 and the parent dir excludes group/other.

Needs review (not auto-merged): security-sensitive auth change, and the POSIX file-mode assertions run only in CI (Linux) — they are skipped on the Windows dev host so I could not exercise that path locally.

Closes #157