### PR TITLE
fix(http): add timeout and redirect control to outbound fetch calls

### DIFF
--- a/packages/mcp-core/src/__tests__/http.test.ts
+++ b/packages/mcp-core/src/__tests__/http.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchWithTimeout, fetchTimeoutMs } from '../http.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.FERRLABS_MCP_HTTP_TIMEOUT_MS;
+});
+
+describe('fetchTimeoutMs', () => {
+  it('defaults to 15000ms', () => {
+    expect(fetchTimeoutMs()).toBe(15_000);
+  });
+
+  it('honours a valid override', () => {
+    process.env.FERRLABS_MCP_HTTP_TIMEOUT_MS = '500';
+    expect(fetchTimeoutMs()).toBe(500);
+  });
+
+  it('ignores a non-positive or non-numeric override', () => {
+    process.env.FERRLABS_MCP_HTTP_TIMEOUT_MS = 'nope';
+    expect(fetchTimeoutMs()).toBe(15_000);
+    process.env.FERRLABS_MCP_HTTP_TIMEOUT_MS = '0';
+    expect(fetchTimeoutMs()).toBe(15_000);
+  });
+});
+
+describe('fetchWithTimeout', () => {
+  it('aborts and throws a timeout error when the upstream hangs', async () => {
+    vi.stubGlobal('fetch', (_url: string, init: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => {
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+        });
+      });
+    });
+
+    await expect(fetchWithTimeout('https://example.test', {}, 10)).rejects.toThrow(/timed out/);
+  });
+
+  it('passes the signal through and returns the response on success', async () => {
+    const ok = { ok: true } as Response;
+    const seen: { signal?: AbortSignal } = {};
+    vi.stubGlobal('fetch', (_url: string, init: RequestInit) => {
+      seen.signal = init.signal ?? undefined;
+      return Promise.resolve(ok);
+    });
+
+    await expect(fetchWithTimeout('https://example.test')).resolves.toBe(ok);
+    expect(seen.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/packages/mcp-core/src/api-client.ts
+++ b/packages/mcp-core/src/api-client.ts
@@ -1,5 +1,6 @@
 import { clearPersistedToken } from './auth/persistence.js';
 import { clearTokenCache } from './auth/index.js';
+import { fetchWithTimeout } from './http.js';
 
 const DEFAULT_API_URL = process.env.API_URL ?? 'https://api.ferrlabs.com';
 
@@ -36,7 +37,7 @@ export async function apiRequest<T>(path: string, options: RequestOptions = {}):
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  const res = await fetch(`${base}${path}`, {
+  const res = await fetchWithTimeout(`${base}${path}`, {
     method,
     headers,
     body: body ? JSON.stringify(body) : undefined,

--- a/packages/mcp-core/src/auth/oauth.ts
+++ b/packages/mcp-core/src/auth/oauth.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { spawn } from 'node:child_process';
 import { platform } from 'node:os';
+import { fetchWithTimeout } from '../http.js';
 
 const AUTH_BASE = process.env.FERRLABS_AUTH_URL ?? 'https://auth.ferrlabs.com';
 const API_BASE = process.env.API_URL ?? 'https://api.ferrlabs.com';
@@ -125,7 +126,7 @@ async function exchangeCodeForToken(
   codeVerifier: string,
   redirectUri: string,
 ): Promise<string> {
-  const res = await fetch(`${API_BASE}/v1/auth/exchange`, {
+  const res = await fetchWithTimeout(`${API_BASE}/v1/auth/exchange`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'User-Agent': 'ferrlabs-mcp/oauth' },
     body: JSON.stringify({

--- a/packages/mcp-core/src/http.ts
+++ b/packages/mcp-core/src/http.ts
@@ -1,0 +1,27 @@
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export function fetchTimeoutMs(): number {
+  const raw = process.env.FERRLABS_MCP_HTTP_TIMEOUT_MS;
+  if (!raw) return DEFAULT_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT_MS;
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = fetchTimeoutMs(),
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error(`Request to ${url} timed out after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -3,3 +3,4 @@ export { apiRequest, UnauthorizedError } from './api-client.js';
 export { getToken, clearTokenCache } from './auth/index.js';
 export { runWithAuthContext, getRequestBearerToken } from './auth/context.js';
 export type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+export { fetchWithTimeout, fetchTimeoutMs } from './http.js';

--- a/packages/mcp/src/tools/__tests__/docs.test.ts
+++ b/packages/mcp/src/tools/__tests__/docs.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildDocUrl, fetchDoc } from '../docs.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('buildDocUrl', () => {
+  it('maps a product and slug to the allowlisted host', () => {
+    expect(buildDocUrl('ferrflow', 'docs/getting-started')).toBe(
+      'https://ferrflow.com/docs/getting-started',
+    );
+    expect(buildDocUrl('ferrlabs')).toBe('https://ferrlabs.com/');
+  });
+
+  it('rejects slugs containing a scheme, traversal, or a leading //', () => {
+    expect(() => buildDocUrl('ferrflow', 'https://evil.test')).toThrow(/invalid slug/);
+    expect(() => buildDocUrl('ferrflow', '../../etc/passwd')).toThrow(/invalid slug/);
+    expect(() => buildDocUrl('ferrflow', '//evil.test/x')).toThrow(/invalid slug/);
+  });
+
+  it('rejects an unknown product', () => {
+    expect(() => buildDocUrl('notaproduct')).toThrow(/unknown product/);
+  });
+});
+
+describe('fetchDoc', () => {
+  function makeResponse(status: number, body = ''): Response {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: () => Promise.resolve(body),
+    } as unknown as Response;
+  }
+
+  it('does not follow a redirect off the allowlisted host', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(302));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchDoc('ferrgrowth', 'r')).rejects.toThrow(/refused to follow redirect/);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+  });
+
+  it('returns stripped text on a 200', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeResponse(200, '<main><p>hello world</p></main>')),
+    );
+
+    const out = await fetchDoc('ferrflow', 'pricing');
+    expect(out).toContain('# https://ferrflow.com/pricing');
+    expect(out).toContain('hello world');
+  });
+});

--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { fetchWithTimeout } from '@ferrlabs/mcp-core';
 
 const PRODUCT_HOSTS: Record<string, string> = {
   ferrlabs: 'https://ferrlabs.com',
@@ -32,6 +33,50 @@ function stripHtml(html: string): string {
     .trim();
 }
 
+export function buildDocUrl(product: string, slug?: string): string {
+  const host = PRODUCT_HOSTS[product];
+  if (!host) {
+    throw new Error(`fetch_docs: unknown product '${product}'`);
+  }
+  if (slug !== undefined) {
+    if (slug.includes('://') || slug.includes('..') || slug.startsWith('//')) {
+      throw new Error(
+        `fetch_docs: invalid slug '${slug}' — must be a relative path without '://', '..', or a leading '//'`,
+      );
+    }
+  }
+  const path = slug ? `/${slug.replace(/^\//, '')}` : '/';
+  return `${host}${path}`;
+}
+
+export async function fetchDoc(product: string, slug?: string): Promise<string> {
+  const url = buildDocUrl(product, slug);
+
+  const res = await fetchWithTimeout(url, {
+    redirect: 'manual',
+    headers: {
+      'User-Agent': 'ferrlabs-mcp',
+      Accept: 'text/html,text/markdown,text/plain',
+    },
+  });
+
+  if (res.status >= 300 && res.status < 400) {
+    throw new Error(
+      `fetch_docs ${url}: refused to follow redirect (HTTP ${res.status}) off the allowlisted host`,
+    );
+  }
+
+  if (!res.ok) {
+    throw new Error(`fetch_docs ${url}: HTTP ${res.status}`);
+  }
+
+  const raw = await res.text();
+  const text = stripHtml(raw);
+  const truncated = text.length > MAX_BYTES;
+  const out = truncated ? `${text.slice(0, MAX_BYTES)}\n\n[truncated]` : text;
+  return `# ${url}\n\n${out}`;
+}
+
 export function registerDocsTools(server: McpServer) {
   server.tool(
     'fetch_docs',
@@ -46,31 +91,12 @@ export function registerDocsTools(server: McpServer) {
         ),
     },
     async ({ product, slug }) => {
-      const host = PRODUCT_HOSTS[product];
-      const path = slug ? `/${slug.replace(/^\//, '')}` : '/';
-      const url = `${host}${path}`;
-
-      const res = await fetch(url, {
-        headers: {
-          'User-Agent': 'ferrlabs-mcp/4.0.0',
-          Accept: 'text/html,text/markdown,text/plain',
-        },
-      });
-
-      if (!res.ok) {
-        throw new Error(`fetch_docs ${url}: HTTP ${res.status}`);
-      }
-
-      const raw = await res.text();
-      const text = stripHtml(raw);
-      const truncated = text.length > MAX_BYTES;
-      const out = truncated ? `${text.slice(0, MAX_BYTES)}\n\n[truncated]` : text;
-
+      const text = await fetchDoc(product, slug);
       return {
         content: [
           {
             type: 'text' as const,
-            text: `# ${url}\n\n${out}`,
+            text,
           },
         ],
       };


### PR DESCRIPTION
Every outbound HTTP call used bare `fetch` with no timeout and no redirect policy. A hung upstream (`api.ferrlabs.com`, a product site, the OAuth exchange) would wedge the whole MCP session over stdio with no error, and `fetch_docs` followed redirects by default — a product host that 30x-redirects off-domain would be fetched past the `PRODUCT_HOSTS` allowlist (mild SSRF).

Changes:
- New `fetchWithTimeout` helper in `@ferrlabs/mcp-core` (`AbortController`, default 15s, overridable via `FERRLABS_MCP_HTTP_TIMEOUT_MS`); maps an abort to a clear `timed out` error. Used by `apiRequest` and the OAuth `exchangeCodeForToken`.
- `fetch_docs` now sets `redirect: 'manual'` and rejects any 3xx instead of following it off the allowlisted host, and rejects slugs containing `://`, `..`, or a leading `//`. Extracted `buildDocUrl`/`fetchDoc` so the validation and redirect paths are unit-testable.

Tests: `mcp-core/src/__tests__/http.test.ts` covers the timeout abort, the env override, and signal pass-through; `mcp/src/tools/__tests__/docs.test.ts` covers slug rejection, unknown product, and the redirect-refusal path. `pnpm build` + `pnpm typecheck` + `pnpm test` all green locally (37 tests).

Closes #159
Refs #177 (low: fetch_docs follows redirects on user-influenced paths)