### PR TITLE
fix(transport): harden HTTP transport CORS, bind, host, and body size

### DIFF
--- a/packages/mcp-core/src/transports/__tests__/http.test.ts
+++ b/packages/mcp-core/src/transports/__tests__/http.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { unauthorizedChallenge } from '../http.js';
+import {
+  unauthorizedChallenge,
+  resolveAllowedOrigin,
+  isHostAllowed,
+  defaultBindHost,
+  parseList,
+} from '../http.js';
 
 describe('unauthorizedChallenge', () => {
   const metadataUrl = 'https://mcp.ferrvault.com/.well-known/oauth-protected-resource';
@@ -24,5 +30,69 @@ describe('unauthorizedChallenge', () => {
     expect(wwwAuthenticate.startsWith('Bearer ')).toBe(true);
     expect(wwwAuthenticate).toContain('error="invalid_token"');
     expect(wwwAuthenticate).toContain(`resource_metadata="${metadataUrl}"`);
+  });
+});
+
+describe('resolveAllowedOrigin', () => {
+  const allowlist = ['https://app.ferrlabs.com', 'http://localhost:5173'];
+
+  it('echoes an origin that is on the allowlist', () => {
+    expect(resolveAllowedOrigin('https://app.ferrlabs.com', allowlist)).toBe(
+      'https://app.ferrlabs.com',
+    );
+  });
+
+  it('refuses to reflect an origin that is not allowlisted', () => {
+    expect(resolveAllowedOrigin('https://evil.test', allowlist)).toBeUndefined();
+  });
+
+  it('returns undefined when no origin header is present', () => {
+    expect(resolveAllowedOrigin(undefined, allowlist)).toBeUndefined();
+  });
+
+  it('never falls back to a wildcard when the allowlist is empty', () => {
+    expect(resolveAllowedOrigin('https://app.ferrlabs.com', [])).toBeUndefined();
+  });
+});
+
+describe('isHostAllowed', () => {
+  it('allows any host when no allowlist is configured', () => {
+    expect(isHostAllowed('anything.test', [])).toBe(true);
+  });
+
+  it('matches the host ignoring port and case', () => {
+    expect(isHostAllowed('MCP.ferrlabs.com:3000', ['mcp.ferrlabs.com'])).toBe(true);
+  });
+
+  it('rejects a host outside the allowlist (DNS-rebinding guard)', () => {
+    expect(isHostAllowed('attacker.test', ['mcp.ferrlabs.com'])).toBe(false);
+  });
+
+  it('rejects a missing host header when an allowlist is set', () => {
+    expect(isHostAllowed(undefined, ['mcp.ferrlabs.com'])).toBe(false);
+  });
+});
+
+describe('defaultBindHost', () => {
+  it('defaults to loopback', () => {
+    expect(defaultBindHost(undefined, false)).toBe('127.0.0.1');
+  });
+
+  it('binds all interfaces only when explicitly opted in', () => {
+    expect(defaultBindHost(undefined, true)).toBe('0.0.0.0');
+  });
+
+  it('honours an explicit host over the opt-in flag', () => {
+    expect(defaultBindHost('10.0.0.5', true)).toBe('10.0.0.5');
+  });
+});
+
+describe('parseList', () => {
+  it('splits, trims, and drops empties', () => {
+    expect(parseList(' a , b ,, c ')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty array for undefined', () => {
+    expect(parseList(undefined)).toEqual([]);
   });
 });

--- a/packages/mcp-core/src/transports/http.ts
+++ b/packages/mcp-core/src/transports/http.ts
@@ -8,11 +8,41 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { runWithAuthContext } from '../auth/context.js';
 
+const MAX_BODY_BYTES = 1_000_000;
+
 function extractBearer(req: IncomingMessage): string | undefined {
   const header = req.headers['authorization'];
   if (typeof header !== 'string') return undefined;
   const match = /^Bearer\s+(.+)$/i.exec(header);
   return match?.[1];
+}
+
+export function parseList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export function resolveAllowedOrigin(
+  requestOrigin: string | undefined,
+  allowlist: string[],
+): string | undefined {
+  if (requestOrigin === undefined) return undefined;
+  return allowlist.includes(requestOrigin) ? requestOrigin : undefined;
+}
+
+export function isHostAllowed(hostHeader: string | undefined, allowedHosts: string[]): boolean {
+  if (allowedHosts.length === 0) return true;
+  if (!hostHeader) return false;
+  const host = hostHeader.split(':')[0].toLowerCase();
+  return allowedHosts.some((allowed) => allowed.split(':')[0].toLowerCase() === host);
+}
+
+export function defaultBindHost(envHost: string | undefined, bindAll: boolean): string {
+  if (envHost) return envHost;
+  return bindAll ? '0.0.0.0' : '127.0.0.1';
 }
 
 function publicOrigin(req: IncomingMessage): string {
@@ -59,11 +89,27 @@ export interface HttpServerOptions {
   authorizationServer?: string;
 }
 
+class PayloadTooLargeError extends Error {
+  constructor() {
+    super(`Request body exceeds the ${MAX_BODY_BYTES}-byte limit`);
+    this.name = 'PayloadTooLargeError';
+  }
+}
+
 async function readJsonBody(req: IncomingMessage): Promise<unknown | undefined> {
   if (req.method !== 'POST') return undefined;
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on('data', (c: Buffer) => chunks.push(c));
+    let total = 0;
+    req.on('data', (c: Buffer) => {
+      total += c.length;
+      if (total > MAX_BODY_BYTES) {
+        req.destroy();
+        reject(new PayloadTooLargeError());
+        return;
+      }
+      chunks.push(c);
+    });
     req.on('end', () => {
       const raw = Buffer.concat(chunks).toString('utf8');
       if (!raw) return resolve(undefined);
@@ -78,7 +124,11 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown | undefined> 
 }
 
 export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
-  const { port, host = '0.0.0.0', stateless = true } = opts;
+  const { port, stateless = true } = opts;
+  const bindAll = process.env.FERRLABS_MCP_BIND_ALL === '1';
+  const host = defaultBindHost(opts.host, bindAll);
+  const allowedOrigins = parseList(process.env.FERRLABS_MCP_ALLOWED_ORIGINS);
+  const allowedHosts = parseList(process.env.FERRLABS_MCP_ALLOWED_HOSTS);
   const authServer =
     opts.authorizationServer ?? process.env.FERRLABS_AUTH_URL ?? 'https://api.ferrlabs.com';
   const transports = new Map<string, StreamableHTTPServerTransport>();
@@ -156,15 +206,16 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
   }
 
   function applyCorsHeaders(req: IncomingMessage, res: ServerResponse): void {
-    const origin = (req.headers.origin as string | undefined) ?? '*';
-    res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Vary', 'Origin');
+    const allowed = resolveAllowedOrigin(req.headers.origin as string | undefined, allowedOrigins);
+    if (!allowed) return;
+    res.setHeader('Access-Control-Allow-Origin', allowed);
     res.setHeader('Access-Control-Allow-Credentials', 'true');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    const requested =
-      (req.headers['access-control-request-headers'] as string | undefined) ??
-      'authorization, content-type, mcp-session-id, mcp-protocol-version';
-    res.setHeader('Access-Control-Allow-Headers', requested);
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'authorization, content-type, mcp-session-id, mcp-protocol-version',
+    );
     res.setHeader('Access-Control-Expose-Headers', 'mcp-session-id, www-authenticate');
     res.setHeader('Access-Control-Max-Age', '86400');
   }
@@ -175,6 +226,12 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
     if (req.method === 'OPTIONS') {
       res.writeHead(204);
       res.end();
+      return;
+    }
+
+    if (!isHostAllowed(req.headers.host, allowedHosts)) {
+      res.writeHead(421, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Host not allowed' }));
       return;
     }
 
@@ -191,7 +248,8 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<void> {
     if (url === '/mcp' || url.startsWith('/mcp?')) {
       handleMcpRequest(req, res).catch((err) => {
         if (!res.headersSent) {
-          res.writeHead(500, { 'Content-Type': 'application/json' });
+          const status = err instanceof PayloadTooLargeError ? 413 : 500;
+          res.writeHead(status, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
         } else {
           res.end();


### PR DESCRIPTION
The Streamable HTTP transport had several compounding weaknesses (it carries `Authorization: Bearer fl_...` tokens that map to full FerrLabs API access):

- **Reflected-origin CORS with credentials.** `applyCorsHeaders` echoed any `Origin` back with `Access-Control-Allow-Credentials: true`. Replaced with an explicit allowlist (`FERRLABS_MCP_ALLOWED_ORIGINS`); a non-allowlisted origin now receives no `Access-Control-Allow-Origin` at all, and there is no wildcard fallback.
- **Binds 0.0.0.0 by default.** Default bind is now `127.0.0.1`; binding all interfaces requires `FERRLABS_MCP_BIND_ALL=1` (or an explicit `HOST`).
- **No DNS-rebinding guard.** Added an optional `Host`-header allowlist (`FERRLABS_MCP_ALLOWED_HOSTS`); a request whose `Host` is outside the list is rejected with 421.
- **Unbounded request body.** `readJsonBody` now caps the body at 1 MB and returns 413 instead of buffering arbitrarily large payloads before the bearer check.

The CORS/bind/host logic is extracted into pure functions (`resolveAllowedOrigin`, `isHostAllowed`, `defaultBindHost`, `parseList`) and unit-tested in `transports/__tests__/http.test.ts`. `pnpm build` + `pnpm typecheck` + `pnpm test` green locally (40 tests).

Behaviour change: browser CORS now requires `FERRLABS_MCP_ALLOWED_ORIGINS` to be configured; non-browser clients (Bearer header, no cookies) are unaffected. Default bind is now loopback.

Needs review (not auto-merged): security-sensitive transport change with a CORS/bind behaviour change; the end-to-end HTTP request paths (413, 421, CORS echo) are exercised via the extracted helpers rather than a live server harness.

Closes #156
Refs #177 (low: reflected Origin with credentials; security: no rate limit / size cap)