### PR TITLE
chore(ci): add release concurrency and pin checkout to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,16 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish-npm:
     name: Publish npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
       - uses: pnpm/action-setup@v6
@@ -58,7 +62,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
       - uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Applies the standard release-workflow fix from FerrLabs/.github#56 to `release.yml`:

- Workflow-level `concurrency` group (`release-${{ github.ref }}`, `cancel-in-progress: false`) so concurrent release runs don't race.
- Pin `actions/checkout@v6` → `@v5` on both jobs — v6 drops `GITHUB_TOKEN` on `fetch-depth: 0`, which silently breaks token-dependent git operations.

YAML validated locally.

Closes #155