### PR TITLE
style: reformat with prettier 3.8.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce:
+
 1.
 2.
 3.
@@ -19,6 +20,7 @@ Steps to reproduce:
 What you expected to happen.
 
 **Environment**
+
 - MCP version:
 - Transport: HTTP / stdio
 - Logs:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 | Version | Supported |
-|---------|-----------|
+| ------- | --------- |
 | latest  | Yes       |
 
 Only the latest release receives security updates.

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,4 +16,4 @@ coverage:
         informational: true
 
 ignore:
-  - ".github/**"
+  - '.github/**'

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>FerrLabs/.github"
-  ]
+  "extends": ["github>FerrLabs/.github"]
 }


### PR DESCRIPTION
prettier 3.8.4 (#180) changed a handful of formatting rules; CI has no `format:check` step so the bump merged green while the tree drifted out of prettier-clean. Ran `pnpm format` (`prettier --write .`) to bring it back in sync.

Formatting-only, no behaviour change. The actual content changes are four files — markdown table/blank-line spacing, single-quote and array-collapse rules:

- `.github/ISSUE_TEMPLATE/bug_report.md` — blank line before lists
- `SECURITY.md` — table separator spacing
- `codecov.yml` — single quotes
- `renovate.json` — collapse single-element array

Closes #191